### PR TITLE
feat: support multiple collaterals

### DIFF
--- a/hh_test/CollateralSystem.spec.ts
+++ b/hh_test/CollateralSystem.spec.ts
@@ -52,12 +52,7 @@ describe("CollateralSystem", function () {
 
     await collateralSystem
       .connect(deployer)
-      .UpdateTokenInfos(
-        [formatBytes32String("ATH")],
-        [athToken.address],
-        [1],
-        [false]
-      );
+      .updateTokenInfo(formatBytes32String("ATH"), athToken.address, 1, false);
   });
 
   it("only reward locker can call collateralFromUnlockReward function", async () => {
@@ -178,7 +173,7 @@ describe("CollateralSystem", function () {
           ethers.utils.formatBytes32String("ETH"),
           expandTo18Decimals(10)
         )
-    ).to.be.revertedWith("CollateralSystem: Invalid token symbol");
+    ).to.be.revertedWith("CollateralSystem: currency symbol mismatch");
 
     let athTokeninfo = await collateralSystem.tokenInfos(
       formatBytes32String("ATH")

--- a/hh_test/CollateralSystem.spec.ts
+++ b/hh_test/CollateralSystem.spec.ts
@@ -41,7 +41,8 @@ describe("CollateralSystem", function () {
 
     athToken = await MockERC20.deploy(
       "Athos Finance", // _name
-      "ATH" // _symbol
+      "ATH", // _symbol
+      18 // _decimals
     );
 
     assetRegistry = await AssetRegistry.deploy();

--- a/hh_test/RewardSystem.spec.ts
+++ b/hh_test/RewardSystem.spec.ts
@@ -92,7 +92,8 @@ describe("RewardSystem", function () {
 
     ausd = await MockERC20.deploy(
       "athUSD", // _name
-      "athUSD" // _symbol
+      "athUSD", // _symbol
+      18 // _decimals
     );
 
     collateralSystem = await waffle.deployMockContract(

--- a/hh_test/integration/Build.spec.ts
+++ b/hh_test/integration/Build.spec.ts
@@ -30,13 +30,13 @@ describe("Integration | Build", function () {
     );
 
     // Mint 1,000,000 ATH to Alice
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(deployer)
       .transfer(alice.address, expandTo18Decimals(1_000_000));
 
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(alice)
-      .approve(stack.collateralSystem.address, uint256Max);
+      .approve(stack.collaterals.ath.collateralSystem.address, uint256Max);
   });
 
   it("can build athUSD with just locked reward", async function () {
@@ -48,7 +48,7 @@ describe("Integration | Build", function () {
     );
 
     // Alice can build 1 athUSD without staking
-    await stack.buildBurnSystem.connect(alice).BuildAsset(
+    await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
       expandTo18Decimals(1) // amount
     );
 
@@ -59,14 +59,14 @@ describe("Integration | Build", function () {
 
   it("maxRedeemableLina() should return staked amount when debt is zero regardless of locked collateral", async function () {
     // Alice stakes 9,000 ATH
-    await stack.collateralSystem.connect(alice).Collateral(
+    await stack.collaterals.ath.collateralSystem.connect(alice).Collateral(
       formatBytes32String("ATH"), // _currency
       expandTo18Decimals(9_000) // _amount
     );
 
     // Returns 9,000 when locked amount is zero
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));
@@ -80,7 +80,7 @@ describe("Integration | Build", function () {
 
     // Returns 9,000 when locked amount is less than staked
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));
@@ -94,7 +94,7 @@ describe("Integration | Build", function () {
 
     // Returns 9,000 when locked amount is the same as staked
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));
@@ -108,7 +108,7 @@ describe("Integration | Build", function () {
 
     // Returns 9,000 when locked amount is the same as staked
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));
@@ -116,19 +116,19 @@ describe("Integration | Build", function () {
 
   it("maxRedeemableLina() should reflect debt amount", async function () {
     // Alice stakes 9,000 ATH
-    await stack.collateralSystem.connect(alice).Collateral(
+    await stack.collaterals.ath.collateralSystem.connect(alice).Collateral(
       formatBytes32String("ATH"), // _currency
       expandTo18Decimals(9_000) // _amount
     );
 
     // Alice builds 10 athUSD
-    await stack.buildBurnSystem.connect(alice).BuildAsset(
+    await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
       expandTo18Decimals(10) // amount
     );
 
     // 5,000 ATH is set aside
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(4_000));
@@ -142,7 +142,7 @@ describe("Integration | Build", function () {
 
     // Now 8,000 ATH is withdrawable
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(8_000));
@@ -156,7 +156,7 @@ describe("Integration | Build", function () {
 
     // All staked amount available
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));
@@ -168,7 +168,7 @@ describe("Integration | Build", function () {
       [(await getBlockDateTime(ethers.provider)).plus({ years: 1 }).toSeconds()] // _lockTo
     );
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));

--- a/hh_test/integration/Exchange.spec.ts
+++ b/hh_test/integration/Exchange.spec.ts
@@ -89,21 +89,21 @@ describe("Integration | Exchange", function () {
     );
 
     // Mint 1,000,000 ATH to Alice
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(deployer)
       .transfer(alice.address, expandTo18Decimals(1_000_000));
 
     // Alice stakes all ATH
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(alice)
-      .approve(stack.collateralSystem.address, uint256Max);
-    await stack.collateralSystem.connect(alice).Collateral(
+      .approve(stack.collaterals.ath.collateralSystem.address, uint256Max);
+    await stack.collaterals.ath.collateralSystem.connect(alice).Collateral(
       formatBytes32String("ATH"), // _currency
       expandTo18Decimals(1_000_000) // _amount
     );
 
     // Alice builds 1,000 athUSD
-    await stack.buildBurnSystem.connect(alice).BuildAsset(
+    await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
       expandTo18Decimals(1_000) // amount
     );
   });

--- a/hh_test/integration/Multicollateral.spec.ts
+++ b/hh_test/integration/Multicollateral.spec.ts
@@ -1,0 +1,250 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+
+import {
+  expandTo18Decimals,
+  expandTo8Decimals,
+  uint256Max,
+} from "../utilities";
+import { deployAthosStack, DeployedStack } from "../utilities/init";
+import { getBlockDateTime } from "../utilities/timeTravel";
+
+const { formatBytes32String } = ethers.utils;
+
+describe("Integration | Multicollateral", function () {
+  let deployer: SignerWithAddress, alice: SignerWithAddress;
+
+  let stack: DeployedStack;
+
+  beforeEach(async function () {
+    [deployer, alice] = await ethers.getSigners();
+
+    stack = await deployAthosStack(deployer);
+
+    // Set ATH price to $0.01
+    await stack.athOracle.connect(deployer).setPrice(
+      expandTo8Decimals(0.01) // price
+    );
+    // Set WBTC price to $20,000
+    await stack.wbtcOracle.connect(deployer).setPrice(
+      expandTo8Decimals(20_000) // price
+    );
+
+    // Mint 1,000,000 ATH and 10 WBTC to Alice
+    await stack.collaterals.ath.token
+      .connect(deployer)
+      .transfer(alice.address, expandTo18Decimals(1_000_000));
+    await stack.collaterals.wbtc.token
+      .connect(deployer)
+      .transfer(alice.address, expandTo8Decimals(10));
+
+    await stack.collaterals.ath.token
+      .connect(alice)
+      .approve(stack.collaterals.ath.collateralSystem.address, uint256Max);
+    await stack.collaterals.wbtc.token
+      .connect(alice)
+      .approve(stack.collaterals.wbtc.collateralSystem.address, uint256Max);
+  });
+
+  describe("Collateral Staking", function () {
+    it("can stake and unstake WBTC", async function () {
+      // Alice has 10 WBTC
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(alice.address)
+      ).to.equal(expandTo8Decimals(10));
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(
+          stack.collaterals.wbtc.collateralSystem.address
+        )
+      ).to.equal(0);
+
+      // Alice stakes 3 WBTC
+      await stack.collaterals.wbtc.collateralSystem.connect(alice).Collateral(
+        formatBytes32String("WBTC"), // _currency
+        expandTo8Decimals(3) // _amount
+      );
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(alice.address)
+      ).to.equal(expandTo8Decimals(7));
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(
+          stack.collaterals.wbtc.collateralSystem.address
+        )
+      ).to.equal(expandTo8Decimals(3));
+
+      // Alice unstakes 1 WBTC
+      await stack.collaterals.wbtc.collateralSystem.connect(alice).Redeem(
+        formatBytes32String("WBTC"), // _currency
+        expandTo8Decimals(1) // _amount
+      );
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(alice.address)
+      ).to.equal(expandTo8Decimals(8));
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(
+          stack.collaterals.wbtc.collateralSystem.address
+        )
+      ).to.equal(expandTo8Decimals(2));
+
+      // Alice unstakes everything
+      await stack.collaterals.wbtc.collateralSystem.connect(alice).RedeemMax(
+        formatBytes32String("WBTC") // _currency
+      );
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(alice.address)
+      ).to.equal(expandTo8Decimals(10));
+      expect(
+        await stack.collaterals.wbtc.token.balanceOf(
+          stack.collaterals.wbtc.collateralSystem.address
+        )
+      ).to.equal(0);
+    });
+  });
+
+  describe("Building athUSD", function () {
+    beforeEach(async function () {
+      // Alice stakes 10,000 ATH
+      await stack.collaterals.ath.collateralSystem.connect(alice).Collateral(
+        formatBytes32String("ATH"), // _currency
+        expandTo18Decimals(10_000) // _amount
+      );
+
+      // Alice stakes 1 WBTC
+      await stack.collaterals.wbtc.collateralSystem.connect(alice).Collateral(
+        formatBytes32String("WBTC"), // _currency
+        expandTo8Decimals(1) // _amount
+      );
+    });
+
+    it("can build athUSD with WBTC collateral", async function () {
+      // Maximun amount of athUSD Alice can build:
+      //
+      // 1 * 20000 * 0.5 = 10000 athUSD
+      //
+      // Trying to build 10001 athUSD will fail
+      await expect(
+        stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+          expandTo18Decimals(10_001) // amount
+        )
+      ).to.revertedWith("Build amount too big, you need more collateral");
+
+      // Building 10000 athUSD works
+      await stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(10_000) // amount
+      );
+
+      expect(await stack.ausdToken.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(10_000)
+      );
+    });
+
+    it("ATH balances should not affect building from WBTC", async function () {
+      // Alice gets 10,000 ATH locked balance (she already has 10,000 ATH staked)
+      await stack.rewardLocker.connect(deployer).migrateRewards(
+        [alice.address], // _users
+        [expandTo18Decimals(10_000)], // _amounts
+        [
+          (await getBlockDateTime(ethers.provider))
+            .plus({ years: 1 })
+            .toSeconds(),
+        ] // _lockTo
+      );
+
+      // Alice can still only build 10,000 athUSD
+      await expect(
+        stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+          expandTo18Decimals(10_001) // amount
+        )
+      ).to.revertedWith("Build amount too big, you need more collateral");
+      await stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(10_000) // amount
+      );
+    });
+
+    it("athUSD from different collaterals are fungible", async function () {
+      // Alice has no athUSD to begin with
+      expect(await stack.ausdToken.balanceOf(alice.address)).to.equal(0);
+
+      // Alice builds 10 athUSD from ATH
+      await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(10) // amount
+      );
+
+      // athUSD token balance increases
+      expect(await stack.ausdToken.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(10)
+      );
+
+      // Alice builds 20 athUSD from WBTC
+      await stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(20) // amount
+      );
+
+      // The same athUSD token balance increases
+      expect(await stack.ausdToken.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(30)
+      );
+    });
+
+    it("debt from different collaterals are separated", async function () {
+      // Alice has no debt on either side to begin with
+      expect(
+        (
+          await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
+            alice.address
+          )
+        )[0]
+      ).to.equal(0);
+      expect(
+        (
+          await stack.collaterals.wbtc.debtSystem.GetUserDebtBalanceInUsd(
+            alice.address
+          )
+        )[0]
+      ).to.equal(0);
+
+      // Alice builds 10 athUSD from ATH
+      await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(10) // amount
+      );
+
+      // ATH debt increases
+      expect(
+        (
+          await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
+            alice.address
+          )
+        )[0]
+      ).to.equal(expandTo18Decimals(10));
+      expect(
+        (
+          await stack.collaterals.wbtc.debtSystem.GetUserDebtBalanceInUsd(
+            alice.address
+          )
+        )[0]
+      ).to.equal(0);
+
+      // Alice builds 20 athUSD from WBTC
+      await stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(20) // amount
+      );
+
+      // WBTC debt increases
+      expect(
+        (
+          await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
+            alice.address
+          )
+        )[0]
+      ).to.equal(expandTo18Decimals(10));
+      expect(
+        (
+          await stack.collaterals.wbtc.debtSystem.GetUserDebtBalanceInUsd(
+            alice.address
+          )
+        )[0]
+      ).to.equal(expandTo18Decimals(20));
+    });
+  });
+});

--- a/hh_test/integration/Multicollateral.spec.ts
+++ b/hh_test/integration/Multicollateral.spec.ts
@@ -1,5 +1,7 @@
+import { Duration } from "luxon";
 import { ethers } from "hardhat";
 import { expect } from "chai";
+import { BigNumberish } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 
 import {
@@ -8,14 +10,45 @@ import {
   uint256Max,
 } from "../utilities";
 import { deployAthosStack, DeployedStack } from "../utilities/init";
-import { getBlockDateTime } from "../utilities/timeTravel";
+import {
+  getBlockDateTime,
+  setNextBlockTimestamp,
+} from "../utilities/timeTravel";
+
+import { IDebtSystem } from "../../typechain";
 
 const { formatBytes32String } = ethers.utils;
+
+enum CollateralType {
+  ATH,
+  WBTC,
+}
 
 describe("Integration | Multicollateral", function () {
   let deployer: SignerWithAddress, alice: SignerWithAddress;
 
   let stack: DeployedStack;
+
+  const assertDebtBalance = async (
+    user: string,
+    collateral: CollateralType,
+    amount: BigNumberish
+  ) => {
+    let debtSystem: IDebtSystem;
+    switch (collateral) {
+      case CollateralType.ATH:
+        debtSystem = stack.collaterals.ath.debtSystem;
+        break;
+      case CollateralType.WBTC:
+        debtSystem = stack.collaterals.wbtc.debtSystem;
+        break;
+      default:
+        throw new Error("Unknown collateral type");
+    }
+    expect((await debtSystem.GetUserDebtBalanceInUsd(user))[0]).to.equal(
+      amount
+    );
+  };
 
   beforeEach(async function () {
     [deployer, alice] = await ethers.getSigners();
@@ -189,20 +222,8 @@ describe("Integration | Multicollateral", function () {
 
     it("debt from different collaterals are separated", async function () {
       // Alice has no debt on either side to begin with
-      expect(
-        (
-          await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
-            alice.address
-          )
-        )[0]
-      ).to.equal(0);
-      expect(
-        (
-          await stack.collaterals.wbtc.debtSystem.GetUserDebtBalanceInUsd(
-            alice.address
-          )
-        )[0]
-      ).to.equal(0);
+      await assertDebtBalance(alice.address, CollateralType.ATH, 0);
+      await assertDebtBalance(alice.address, CollateralType.WBTC, 0);
 
       // Alice builds 10 athUSD from ATH
       await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
@@ -210,20 +231,12 @@ describe("Integration | Multicollateral", function () {
       );
 
       // ATH debt increases
-      expect(
-        (
-          await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
-            alice.address
-          )
-        )[0]
-      ).to.equal(expandTo18Decimals(10));
-      expect(
-        (
-          await stack.collaterals.wbtc.debtSystem.GetUserDebtBalanceInUsd(
-            alice.address
-          )
-        )[0]
-      ).to.equal(0);
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(10)
+      );
+      await assertDebtBalance(alice.address, CollateralType.WBTC, 0);
 
       // Alice builds 20 athUSD from WBTC
       await stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
@@ -231,20 +244,192 @@ describe("Integration | Multicollateral", function () {
       );
 
       // WBTC debt increases
-      expect(
-        (
-          await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
-            alice.address
-          )
-        )[0]
-      ).to.equal(expandTo18Decimals(10));
-      expect(
-        (
-          await stack.collaterals.wbtc.debtSystem.GetUserDebtBalanceInUsd(
-            alice.address
-          )
-        )[0]
-      ).to.equal(expandTo18Decimals(20));
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(10)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(20)
+      );
+    });
+  });
+
+  describe("Debt Changes", function () {
+    const settlementDelay: Duration = Duration.fromObject({ minutes: 1 });
+
+    // Helper functions
+    const setLbtcPrice = async (price: number): Promise<void> => {
+      await stack.abtcOracle.connect(deployer).setPrice(
+        expandTo8Decimals(price) // price
+      );
+    };
+    const passSettlementDelay = async (): Promise<void> => {
+      await setNextBlockTimestamp(
+        ethers.provider,
+        (await getBlockDateTime(ethers.provider)).plus(settlementDelay)
+      );
+    };
+    const settleTrade = (entryId: number): Promise<any> => {
+      return stack.exchangeSystem.connect(deployer).settle(
+        entryId // pendingExchangeEntryId
+      );
+    };
+    const settleTradeWithDelay = async (entryId: number): Promise<any> => {
+      await passSettlementDelay();
+      await settleTrade(entryId);
+    };
+
+    beforeEach(async function () {
+      // Alice stakes 10,000 ATH and 1 WBTC
+      await stack.collaterals.ath.collateralSystem.connect(alice).Collateral(
+        formatBytes32String("ATH"), // _currency
+        expandTo18Decimals(10_000) // _amount
+      );
+      await stack.collaterals.wbtc.collateralSystem.connect(alice).Collateral(
+        formatBytes32String("WBTC"), // _currency
+        expandTo8Decimals(1) // _amount
+      );
+
+      // Alice builds 10 athUSD from ATH and 20 athUSD from WBTC
+      await stack.collaterals.ath.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(10) // amount
+      );
+      await stack.collaterals.wbtc.buildBurnSystem.connect(alice).BuildAsset(
+        expandTo18Decimals(20) // amount
+      );
+
+      // Set settlement delay
+      await stack.config.connect(deployer).setUint(
+        formatBytes32String("TradeSettlementDelay"), // key
+        settlementDelay.as("seconds")
+      );
+      await stack.config.connect(deployer).setUint(
+        formatBytes32String("TradeRevertDelay"), // key
+        Duration.fromObject({ years: 1 }).as("seconds")
+      );
+
+      // Set lBTC price to $20,000
+      await setLbtcPrice(20_000);
+
+      // Alice exchanges 10 athUSD for 0.0005 lBTC
+      await stack.exchangeSystem.connect(alice).exchange(
+        formatBytes32String("athUSD"), // sourceKey
+        expandTo18Decimals(10), // sourceAmount
+        alice.address, // destAddr
+        formatBytes32String("aBTC") // destKey
+      );
+      await settleTradeWithDelay(1);
+    });
+
+    it("exchanging should not affect debt amounts", async function () {
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(10)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(20)
+      );
+    });
+
+    it("debt should increase proportionally across collaterals", async function () {
+      // Set lBTC price to $80,000
+      await setLbtcPrice(80_000);
+
+      // Total debt now:
+      //   20 lUSD
+      //   0.0005 lBTC = 0.0005 * 80,000 = 40 lUSD
+      //   Total = 20 + 40 = 60 lUSD
+      //
+      // Per collateral:
+      //   ATH: 20 lUSD
+      //   WBTC: 40 lUSD
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(20)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(40)
+      );
+    });
+
+    it("debt should decrease proportionally across collaterals", async function () {
+      // Set lBTC price to $2,000
+      await setLbtcPrice(2_000);
+
+      // Total debt now:
+      //   20 lUSD
+      //   0.0005 lBTC = 0.0005 * 2,000 = 1 lUSD
+      //   Total = 20 + 1 = 21 lUSD
+      //
+      // Per collateral:
+      //   ATH: 7 lUSD
+      //   WBTC: 14 lUSD
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(7)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(14)
+      );
+    });
+
+    it("burning debt works after debt changes from exchange", async function () {
+      // Set lBTC price to $2,000 so that debt per collateral:
+      //   ATH: 7 lUSD
+      //   WBTC: 14 lUSD
+      await setLbtcPrice(2_000);
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(7)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(14)
+      );
+
+      // Alice burns 2 lUSD of ATH debt
+      await stack.collaterals.ath.buildBurnSystem
+        .connect(alice)
+        .BurnAsset(expandTo18Decimals(2));
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(5)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(14)
+      );
+
+      // Alice burns 4 lUSD of WBTC debt
+      await stack.collaterals.wbtc.buildBurnSystem
+        .connect(alice)
+        .BurnAsset(expandTo18Decimals(4));
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.ATH,
+        expandTo18Decimals(5)
+      );
+      await assertDebtBalance(
+        alice.address,
+        CollateralType.WBTC,
+        expandTo18Decimals(10)
+      );
     });
   });
 });

--- a/hh_test/integration/Perpetual.spec.ts
+++ b/hh_test/integration/Perpetual.spec.ts
@@ -47,7 +47,11 @@ describe("Integration | Perpetual", function () {
 
   const assertAliceDebt = async (amount: BigNumber) => {
     expect(
-      (await stack.debtSystem.GetUserDebtBalanceInUsd(alice.address))[0]
+      (
+        await stack.collaterals.ath.debtSystem.GetUserDebtBalanceInUsd(
+          alice.address
+        )
+      )[0]
     ).to.equal(amount);
   };
 
@@ -103,15 +107,15 @@ describe("Integration | Perpetual", function () {
     );
 
     // Mint 1,000,000 ATH to Alice
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(deployer)
       .transfer(alice.address, expandTo18Decimals(1_000_000));
 
     // Alice stakes all ATH and builds 10,000 athUSD
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(alice)
-      .approve(stack.collateralSystem.address, uint256Max);
-    await stack.collateralSystem.connect(alice).stakeAndBuild(
+      .approve(stack.collaterals.ath.collateralSystem.address, uint256Max);
+    await stack.collaterals.ath.collateralSystem.connect(alice).stakeAndBuild(
       formatBytes32String("ATH"), // stakeCurrnecy
       expandTo18Decimals(1_000_000), // stakeAmount
       expandTo18Decimals(10_000) // buildAmount

--- a/hh_test/integration/UnlockReward.spec.ts
+++ b/hh_test/integration/UnlockReward.spec.ts
@@ -65,15 +65,15 @@ describe("Integration | Unlock Reward", function () {
     stack = await deployAthosStack(deployer);
 
     // Mint 1,000,000 ATH to Alice
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(deployer)
       .transfer(alice.address, expandTo18Decimals(1_000_000));
 
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(alice)
-      .approve(stack.collateralSystem.address, uint256Max);
+      .approve(stack.collaterals.ath.collateralSystem.address, uint256Max);
 
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(alice)
       .transfer(rewarder.address, expandTo18Decimals(10_000));
 
@@ -99,14 +99,14 @@ describe("Integration | Unlock Reward", function () {
 
   it("end to end test from claim reward to unlock reward", async () => {
     // Alice stakes 9,000 ATH
-    await stack.collateralSystem.connect(alice).Collateral(
+    await stack.collaterals.ath.collateralSystem.connect(alice).Collateral(
       formatBytes32String("ATH"), // _currency
       expandTo18Decimals(9_000) // _amount
     );
 
     // Returns 9,000 when locked amount is zero
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_000));
@@ -151,9 +151,12 @@ describe("Integration | Unlock Reward", function () {
     );
 
     // Approve lnCollateralSystem to spend ATH from rewarder
-    await stack.athToken
+    await stack.collaterals.ath.token
       .connect(rewarder)
-      .approve(stack.collateralSystem.address, expandTo18Decimals(100));
+      .approve(
+        stack.collaterals.ath.collateralSystem.address,
+        expandTo18Decimals(100)
+      );
 
     await expect(
       stack.rewardLocker.connect(rewardUnlocker).unlockReward(
@@ -167,47 +170,47 @@ describe("Integration | Unlock Reward", function () {
         alice.address, // user
         expandTo18Decimals(100) // amount
       )
-      .to.emit(stack.collateralSystem, "CollateralUnlockReward")
+      .to.emit(stack.collaterals.ath.collateralSystem, "CollateralUnlockReward")
       .withArgs(
         alice.address,
         formatBytes32String("ATH"),
         expandTo18Decimals(100),
         expandTo18Decimals(9_100)
       )
-      .to.emit(stack.athToken, "Transfer")
+      .to.emit(stack.collaterals.ath.token, "Transfer")
       .withArgs(
         rewarder.address,
-        stack.collateralSystem.address,
+        stack.collaterals.ath.collateralSystem.address,
         expandTo18Decimals(100)
       );
 
     // Returns 9,000 when locked amount is zero
     expect(
-      await stack.collateralSystem.maxRedeemableLina(
+      await stack.collaterals.ath.collateralSystem.maxRedeemableLina(
         alice.address // user
       )
     ).to.equal(expandTo18Decimals(9_100));
 
     await expect(
-      stack.collateralSystem
+      stack.collaterals.ath.collateralSystem
         .connect(alice)
         .RedeemMax(formatBytes32String("ATH"))
     )
-      .to.emit(stack.collateralSystem, "RedeemCollateral")
+      .to.emit(stack.collaterals.ath.collateralSystem, "RedeemCollateral")
       .withArgs(
         alice.address,
         formatBytes32String("ATH"),
         expandTo18Decimals(9_100),
         BigNumber.from("0")
       )
-      .to.emit(stack.athToken, "Transfer")
+      .to.emit(stack.collaterals.ath.token, "Transfer")
       .withArgs(
-        stack.collateralSystem.address,
+        stack.collaterals.ath.collateralSystem.address,
         alice.address,
         expandTo18Decimals(9_100)
       );
 
-    expect(await stack.athToken.balanceOf(alice.address)).to.eq(
+    expect(await stack.collaterals.ath.token.balanceOf(alice.address)).to.eq(
       expandTo18Decimals(990_100)
     );
   });

--- a/hh_test/utilities/init.ts
+++ b/hh_test/utilities/init.ts
@@ -36,7 +36,7 @@ const { formatBytes32String } = ethers.utils;
 const MOCK_ADDRESS: string = "0x0000000000000000000000000000000000000001";
 
 export interface DeployedStack {
-  athToken: AthToken;
+  collaterals: MultiColalteralContracts;
   accessController: AccessController;
   config: Config;
   ausdToken: Asset;
@@ -44,17 +44,26 @@ export interface DeployedStack {
   abtcPerp: Perpetual;
   oracleRouter: OracleRouter;
   assetRegistry: AssetRegistry;
-  debtSystem: DebtSystem;
-  buildBurnSystem: BuildBurnSystem;
-  collateralSystem: CollateralSystem;
   rewardLocker: RewardLocker;
   rewardSystem: RewardSystem;
-  liquidation: Liquidation;
   exchangeSystem: ExchangeSystem;
   perpPositionToken: PerpPositionToken;
   perpExchange: PerpExchange;
   athOracle: MockChainlinkAggregator;
   abtcOracle: MockChainlinkAggregator;
+}
+
+export interface MultiColalteralContracts {
+  ath: CollateralContracts;
+}
+
+export interface CollateralContracts {
+  symbol: String;
+  token: AthToken;
+  debtSystem: DebtSystem;
+  buildBurnSystem: BuildBurnSystem;
+  collateralSystem: CollateralSystem;
+  liquidation: Liquidation;
 }
 
 export const deployAthosStack = async (
@@ -486,7 +495,16 @@ export const deployAthosStack = async (
     .addChainlinkOracle(formatBytes32String("aBTC"), abtcOracle.address, false);
 
   return {
-    athToken: athToken,
+    collaterals: {
+      ath: {
+        symbol: "ATH",
+        token: athToken,
+        debtSystem: debtSystem,
+        buildBurnSystem: buildBurnSystem,
+        collateralSystem: collateralSystem,
+        liquidation: liquidation,
+      },
+    },
     accessController: accessController,
     config: config,
     ausdToken: ausdToken,
@@ -494,12 +512,8 @@ export const deployAthosStack = async (
     abtcPerp: abtcPerp,
     oracleRouter: oracleRouter,
     assetRegistry: assetRegistry,
-    debtSystem: debtSystem,
-    buildBurnSystem: buildBurnSystem,
-    collateralSystem: collateralSystem,
     rewardLocker: rewardLocker,
     rewardSystem: rewardSystem,
-    liquidation: liquidation,
     exchangeSystem: exchangeSystem,
     perpPositionToken: perpPositionToken,
     perpExchange: perpExchange,

--- a/hh_test/utilities/init.ts
+++ b/hh_test/utilities/init.ts
@@ -569,17 +569,17 @@ export const deployAthosStack = async (
   /**
    * Register ATH on `CollateralSystem`
    */
-  await athCollateralSystem.connect(deployer).UpdateTokenInfo(
+  await athCollateralSystem.connect(deployer).updateTokenInfo(
     formatBytes32String("ATH"), // _currency
     athToken.address, // _tokenAddr
     expandTo18Decimals(1), // _minCollateral
-    false // _close
+    false // _disabled
   );
-  await wbtcCollateralSystem.connect(deployer).UpdateTokenInfo(
+  await wbtcCollateralSystem.connect(deployer).updateTokenInfo(
     formatBytes32String("WBTC"), // _currency
     wbtcToken.address, // _tokenAddr
     0_00010000, // _minCollateral
-    false // _close
+    false // _disabled
   );
 
   /**

--- a/hh_test/utilities/init.ts
+++ b/hh_test/utilities/init.ts
@@ -420,7 +420,7 @@ export const deployAthosStack = async (
     .mint(deployer.address, expandTo8Decimals(1_000_000));
 
   /**
-   * Set config items:
+   * Set config items for ATH collateral:
    *
    * - BuildRatio: 0.2
    * - LiquidationRatio: 0.5
@@ -448,6 +448,42 @@ export const deployAthosStack = async (
     {
       key: "LiquidationDelay",
       value: Duration.fromObject({ days: 3 }).as("seconds"),
+    },
+  ])
+    await config.connect(deployer).setUint(
+      ethers.utils.formatBytes32String(item.key), // key
+      item.value // value
+    );
+
+  /**
+   * Set config items for WBTC collateral:
+   *
+   * - BuildRatio: 0.5
+   * - LiquidationRatio: 0.5
+   * - LiquidationMarkerReward: 0.02
+   * - LiquidationLiquidatorReward: 0.05
+   * - LiquidationDelay: 1 day
+   */
+  for (const item of [
+    {
+      key: "WBTC_BuildRatio",
+      value: expandTo18Decimals(0.5),
+    },
+    {
+      key: "WBTC_LiqRatio",
+      value: expandTo18Decimals(0.5),
+    },
+    {
+      key: "WBTC_LiqMarkerReward",
+      value: expandTo18Decimals(0.02),
+    },
+    {
+      key: "WBTC_LiqLiquidatorReward",
+      value: expandTo18Decimals(0.05),
+    },
+    {
+      key: "WBTC_LiqDelay",
+      value: Duration.fromObject({ days: 1 }).as("seconds"),
     },
   ])
     await config.connect(deployer).setUint(

--- a/hh_test/utilities/init.ts
+++ b/hh_test/utilities/init.ts
@@ -8,7 +8,7 @@ import { Duration } from "luxon";
 import { ethers, upgrades } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
-import { expandTo18Decimals, zeroAddress } from ".";
+import { expandTo18Decimals, expandTo8Decimals, zeroAddress } from ".";
 
 import {
   AccessController,
@@ -20,6 +20,7 @@ import {
   Config,
   DebtSystem,
   ExchangeSystem,
+  IERC20,
   Liquidation,
   MockChainlinkAggregator,
   OracleRouter,
@@ -51,15 +52,17 @@ export interface DeployedStack {
   perpExchange: PerpExchange;
   athOracle: MockChainlinkAggregator;
   abtcOracle: MockChainlinkAggregator;
+  wbtcOracle: MockChainlinkAggregator;
 }
 
 export interface MultiColalteralContracts {
   ath: CollateralContracts;
+  wbtc: CollateralContracts;
 }
 
 export interface CollateralContracts {
   symbol: String;
-  token: AthToken;
+  token: IERC20;
   debtSystem: DebtSystem;
   buildBurnSystem: BuildBurnSystem;
   collateralSystem: CollateralSystem;
@@ -120,6 +123,7 @@ export const deployAthosStack = async (
     "MockChainlinkAggregator",
     deployer
   );
+  const MockERC20 = await ethers.getContractFactory("MockERC20", deployer);
 
   const athToken: AthToken = (await upgrades.deployProxy(
     AthToken,
@@ -130,6 +134,12 @@ export const deployAthosStack = async (
       initializer: "__AthToken_init",
     }
   )) as AthToken;
+
+  const wbtcToken = await MockERC20.deploy(
+    "Wrapped BTC", // _name
+    "WBTC", // _symbol
+    8 // _decimals
+  );
 
   const accessController: AccessController = (await upgrades.deployProxy(
     AccessController,
@@ -174,7 +184,7 @@ export const deployAthosStack = async (
     }
   )) as AssetRegistry;
 
-  const debtSystem: DebtSystem = (await upgrades.deployProxy(
+  const athDebtSystem: DebtSystem = (await upgrades.deployProxy(
     DebtSystem,
     [
       accessController.address, // _accessCtrl
@@ -185,11 +195,22 @@ export const deployAthosStack = async (
     }
   )) as DebtSystem;
 
-  const buildBurnSystem: BuildBurnSystem = (await upgrades.deployProxy(
+  const wbtcDebtSystem: DebtSystem = (await upgrades.deployProxy(
+    DebtSystem,
+    [
+      accessController.address, // _accessCtrl
+      assetRegistry.address, // _assetSys
+    ],
+    {
+      initializer: "__DebtSystem_init",
+    }
+  )) as DebtSystem;
+
+  const athBuildBurnSystem: BuildBurnSystem = (await upgrades.deployProxy(
     BuildBurnSystem,
     [
       ausdToken.address, // _lUSDToken
-      debtSystem.address, // _debtSystem
+      athDebtSystem.address, // _debtSystem
       oracleRouter.address, // _priceGetter
       MOCK_ADDRESS, // _collaterSys
       config.address, // _mConfig
@@ -200,14 +221,44 @@ export const deployAthosStack = async (
     }
   )) as BuildBurnSystem;
 
-  const collateralSystem: CollateralSystem = (await upgrades.deployProxy(
+  const wbtcBuildBurnSystem: BuildBurnSystem = (await upgrades.deployProxy(
+    BuildBurnSystem,
+    [
+      ausdToken.address, // _lUSDToken
+      wbtcDebtSystem.address, // _debtSystem
+      oracleRouter.address, // _priceGetter
+      MOCK_ADDRESS, // _collaterSys
+      config.address, // _mConfig
+      MOCK_ADDRESS, // _liquidation
+    ],
+    {
+      initializer: "__BuildBurnSystem_init",
+    }
+  )) as BuildBurnSystem;
+
+  const athCollateralSystem: CollateralSystem = (await upgrades.deployProxy(
     CollateralSystem,
     [
       oracleRouter.address, // _priceGetter
-      debtSystem.address, // _debtSystem
+      athDebtSystem.address, // _debtSystem
       config.address, // _mConfig
       MOCK_ADDRESS, // _mRewardLocker
-      buildBurnSystem.address, // _buildBurnSystem
+      athBuildBurnSystem.address, // _buildBurnSystem
+      MOCK_ADDRESS, // _liquidation
+    ],
+    {
+      initializer: "__CollateralSystem_init",
+    }
+  )) as CollateralSystem;
+
+  const wbtcCollateralSystem: CollateralSystem = (await upgrades.deployProxy(
+    CollateralSystem,
+    [
+      oracleRouter.address, // _priceGetter
+      wbtcDebtSystem.address, // _debtSystem
+      config.address, // _mConfig
+      MOCK_ADDRESS, // _mRewardLocker
+      wbtcBuildBurnSystem.address, // _buildBurnSystem
       MOCK_ADDRESS, // _liquidation
     ],
     {
@@ -234,7 +285,7 @@ export const deployAthosStack = async (
       ).timestamp, // _firstPeriodStartTime
       MOCK_ADDRESS, // _rewardSigner
       ausdToken.address, // _lusdAddress
-      collateralSystem.address, // _collateralSystemAddress
+      athCollateralSystem.address, // _collateralSystemAddress
       rewardLocker.address, // _rewardLockerAddress
     ],
     {
@@ -242,15 +293,31 @@ export const deployAthosStack = async (
     }
   )) as RewardSystem;
 
-  const liquidation: Liquidation = (await upgrades.deployProxy(
+  const athLiquidation: Liquidation = (await upgrades.deployProxy(
     Liquidation,
     [
-      buildBurnSystem.address, // _buildBurnSystem
-      collateralSystem.address, // _collateralSystem
+      athBuildBurnSystem.address, // _buildBurnSystem
+      athCollateralSystem.address, // _collateralSystem
       config.address, // _config
-      debtSystem.address, // _debtSystem
+      athDebtSystem.address, // _debtSystem
       oracleRouter.address, // _oracleRouter
       rewardLocker.address, // _rewardLocker
+    ],
+    {
+      initializer: "__Liquidation_init",
+    }
+  )) as Liquidation;
+
+  // We leave _rewardLocker as MOCK_ADDRESS because it's useless for non-native colalterals.
+  const wbtcLiquidation: Liquidation = (await upgrades.deployProxy(
+    Liquidation,
+    [
+      wbtcBuildBurnSystem.address, // _buildBurnSystem
+      wbtcCollateralSystem.address, // _collateralSystem
+      config.address, // _config
+      wbtcDebtSystem.address, // _debtSystem
+      oracleRouter.address, // _oracleRouter
+      MOCK_ADDRESS, // _rewardLocker
     ],
     {
       initializer: "__Liquidation_init",
@@ -292,30 +359,49 @@ export const deployAthosStack = async (
     }
   )) as PerpExchange;
 
-  // Fix circular dependencies
-  await buildBurnSystem
+  // Fix circular dependencies.
+  //
+  // RewardLocker address is deliberately unset for `wbtcCollateralSystem` in case any bug causes
+  // expected access to it.
+  await athBuildBurnSystem
     .connect(deployer)
-    .setCollateralSystemAddress(collateralSystem.address);
-  await buildBurnSystem
+    .setCollateralSystemAddress(athCollateralSystem.address);
+  await athBuildBurnSystem
     .connect(deployer)
-    .setLiquidationAddress(liquidation.address);
-  await collateralSystem
+    .setLiquidationAddress(athLiquidation.address);
+  await athCollateralSystem
     .connect(deployer)
     .setRewardLockerAddress(rewardLocker.address);
-  await collateralSystem
+  await athCollateralSystem
     .connect(deployer)
-    .setLiquidationAddress(liquidation.address);
+    .setLiquidationAddress(athLiquidation.address);
+  await wbtcBuildBurnSystem
+    .connect(deployer)
+    .setCollateralSystemAddress(wbtcCollateralSystem.address);
+  await wbtcBuildBurnSystem
+    .connect(deployer)
+    .setLiquidationAddress(wbtcLiquidation.address);
+  await wbtcCollateralSystem
+    .connect(deployer)
+    .setLiquidationAddress(wbtcLiquidation.address);
   await rewardLocker
     .connect(deployer)
-    .updateCollateralSystemAddress(collateralSystem.address);
+    .updateCollateralSystemAddress(athCollateralSystem.address);
 
   // Peripherals
   const athOracle: MockChainlinkAggregator =
     await MockChainlinkAggregator.deploy();
   const abtcOracle: MockChainlinkAggregator =
     await MockChainlinkAggregator.deploy();
+  const wbtcOracle: MockChainlinkAggregator =
+    await MockChainlinkAggregator.deploy();
 
   // System initialization starts here
+
+  // Deployer owns 1M WBTC
+  await wbtcToken
+    .connect(deployer)
+    .mint(deployer.address, expandTo8Decimals(1_000_000));
 
   /**
    * Set config items:
@@ -361,13 +447,22 @@ export const deployAthosStack = async (
    */
   await accessController
     .connect(deployer)
-    .grantRole(formatBytes32String("ISSUE_ASSET"), buildBurnSystem.address);
+    .grantRole(formatBytes32String("ISSUE_ASSET"), athBuildBurnSystem.address);
   await accessController
     .connect(deployer)
-    .grantRole(formatBytes32String("BURN_ASSET"), buildBurnSystem.address);
+    .grantRole(formatBytes32String("BURN_ASSET"), athBuildBurnSystem.address);
   await accessController
     .connect(deployer)
-    .grantRole(formatBytes32String("UPDATE_DEBT"), buildBurnSystem.address);
+    .grantRole(formatBytes32String("UPDATE_DEBT"), athBuildBurnSystem.address);
+  await accessController
+    .connect(deployer)
+    .grantRole(formatBytes32String("ISSUE_ASSET"), wbtcBuildBurnSystem.address);
+  await accessController
+    .connect(deployer)
+    .grantRole(formatBytes32String("BURN_ASSET"), wbtcBuildBurnSystem.address);
+  await accessController
+    .connect(deployer)
+    .grantRole(formatBytes32String("UPDATE_DEBT"), wbtcBuildBurnSystem.address);
 
   /**
    * Assign the following roles to contract `ExchangeSystem`:
@@ -388,10 +483,12 @@ export const deployAthosStack = async (
   /**
    * Assign the following role to contract `Liquidation`:
    * - MOVE_REWARD
+   *
+   * Only the native collateral needs this permission.
    */
   await accessController
     .connect(deployer)
-    .grantRole(formatBytes32String("MOVE_REWARD"), liquidation.address);
+    .grantRole(formatBytes32String("MOVE_REWARD"), athLiquidation.address);
 
   /**
    * Assign the following role to contract `RewardSystem`:
@@ -472,10 +569,16 @@ export const deployAthosStack = async (
   /**
    * Register ATH on `CollateralSystem`
    */
-  await collateralSystem.connect(deployer).UpdateTokenInfo(
+  await athCollateralSystem.connect(deployer).UpdateTokenInfo(
     formatBytes32String("ATH"), // _currency
     athToken.address, // _tokenAddr
     expandTo18Decimals(1), // _minCollateral
+    false // _close
+  );
+  await wbtcCollateralSystem.connect(deployer).UpdateTokenInfo(
+    formatBytes32String("WBTC"), // _currency
+    wbtcToken.address, // _tokenAddr
+    0_00010000, // _minCollateral
     false // _close
   );
 
@@ -493,16 +596,28 @@ export const deployAthosStack = async (
   await oracleRouter
     .connect(deployer)
     .addChainlinkOracle(formatBytes32String("aBTC"), abtcOracle.address, false);
+  await wbtcOracle.connect(deployer).setDecimals(8);
+  await oracleRouter
+    .connect(deployer)
+    .addChainlinkOracle(formatBytes32String("WBTC"), wbtcOracle.address, false);
 
   return {
     collaterals: {
       ath: {
         symbol: "ATH",
         token: athToken,
-        debtSystem: debtSystem,
-        buildBurnSystem: buildBurnSystem,
-        collateralSystem: collateralSystem,
-        liquidation: liquidation,
+        debtSystem: athDebtSystem,
+        buildBurnSystem: athBuildBurnSystem,
+        collateralSystem: athCollateralSystem,
+        liquidation: athLiquidation,
+      },
+      wbtc: {
+        symbol: "WBTC",
+        token: wbtcToken,
+        debtSystem: wbtcDebtSystem,
+        buildBurnSystem: wbtcBuildBurnSystem,
+        collateralSystem: wbtcCollateralSystem,
+        liquidation: wbtcLiquidation,
       },
     },
     accessController: accessController,
@@ -519,5 +634,6 @@ export const deployAthosStack = async (
     perpExchange: perpExchange,
     athOracle: athOracle,
     abtcOracle: abtcOracle,
+    wbtcOracle: wbtcOracle,
   };
 };

--- a/src/BuildBurnSystem.sol
+++ b/src/BuildBurnSystem.sol
@@ -81,7 +81,7 @@ contract BuildBurnSystem is PausableUpgradeable, OwnableUpgradeable {
 
     function MaxCanBuildAsset(address user) public view returns (uint256) {
         uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
-        uint256 maxCanBuild = collaterSys.MaxRedeemableInUsd(user).mul(buildRatio).div(SafeDecimalMath.unit());
+        uint256 maxCanBuild = collaterSys.getFreeCollateralInUsd(user).mul(buildRatio).div(SafeDecimalMath.unit());
         return maxCanBuild;
     }
 
@@ -93,7 +93,7 @@ contract BuildBurnSystem is PausableUpgradeable, OwnableUpgradeable {
 
     function _buildAsset(address user, uint256 amount) internal returns (bool) {
         uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
-        uint256 maxCanBuild = collaterSys.MaxRedeemableInUsd(user).multiplyDecimal(buildRatio);
+        uint256 maxCanBuild = collaterSys.getFreeCollateralInUsd(user).multiplyDecimal(buildRatio);
         require(amount <= maxCanBuild, "Build amount too big, you need more collateral");
 
         // calc debt

--- a/src/CollateralSystem.sol
+++ b/src/CollateralSystem.sol
@@ -3,10 +3,9 @@ pragma solidity =0.8.15;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 import "./interfaces/IBuildBurnSystem.sol";
 import "./interfaces/ICollateralSystem.sol";
 import "./interfaces/IConfig.sol";
@@ -16,45 +15,78 @@ import "./interfaces/IRewardLocker.sol";
 import "./libraries/SafeDecimalMath.sol";
 import "./utilities/TransferHelper.sol";
 
+// Note to code reader by Tommy as of 2023-03-07:
+//
+// This contract has been mostly rewritten after it's been deployed in production to properly
+// support multi-collateral, with backward compatibility as a hard requirement.
+//
+// The original codebase assumed that all collateral types will be aggregated into a single USD
+// amount, which is now (at the time of rewrite) considered impractical, as different collaterals
+// have different risk characteristics. The new design is to have each `CollateralSystem` contract
+// handle only a single collateral token.
+//
+// As such, the will be seemingly weird implementations across the contract that might make you
+// wonder why it's even coded that way. Most likely it's for backward compatibility with the
+// previous implementation. For more details check Git history.
 contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgradeable {
     using SafeDecimalMath for uint256;
     using SafeMathUpgradeable for uint256;
     using AddressUpgradeable for address;
 
-    // -------------------------------------------------------
-    // need set before system running value.
+    event UpdateTokenSetting(bytes32 symbol, address tokenAddr, uint256 minCollateral, bool close);
+    event CollateralLog(address user, bytes32 _currency, uint256 _amount, uint256 _userTotal);
+    event RedeemCollateral(address user, bytes32 _currency, uint256 _amount, uint256 _userTotal);
+    event CollateralMoved(address fromUser, address toUser, bytes32 currency, uint256 amount);
+    event CollateralUnlockReward(address user, bytes32 _currency, uint256 _amount, uint256 _userTotal);
+
+    struct TokenInfo {
+        address tokenAddr;
+        uint256 minCollateral;
+        uint256 totalCollateral;
+        bool disabled;
+    }
+
+    struct CollateralData {
+        uint256 collateral;
+    }
+
     IOracleRouter public priceGetter;
     IDebtSystem public debtSystem;
     IConfig public mConfig;
     IRewardLocker public mRewardLocker;
 
-    bytes32 public constant Currency_ETH = "ETH";
-    bytes32 public constant Currency_LINA = "ATH";
+    // This storage slot was previously occupied but not used. The multi-collateral rewrite takes
+    // advantage of it to use it for storing the collateral currency this contract instance deals
+    // with. However, for the already deployed instance (for the native currency), this field will
+    // remain zero. That's why there's a `collateralCurrency` function to determine the actual
+    // currency used.
+    //
+    // This field is made private on purpose to prevent misuse. Callers should use the function
+    // above instead.
+    bytes32 private nonNativeCollateralCurrency;
 
-    // -------------------------------------------------------
-    uint256 public uniqueId; // use log
-
-    struct TokenInfo {
-        address tokenAddr;
-        uint256 minCollateral; // min collateral amount.
-        uint256 totalCollateral;
-        bool bClose;
-    }
-
+    // We're only dealing with one token, but still using mapping to maintain backward-
+    // compatibility.
     mapping(bytes32 => TokenInfo) public tokenInfos;
-    bytes32[] public tokenSymbol; // keys of tokenInfos, use to iteration
 
-    struct CollateralData {
-        uint256 collateral; // total collateral
-    }
+    // This is a storage slot that used to be called `tokenSymbol` for storing all configured
+    // collateral tokens. The slot is kept to not break storage structure but it's no longer needed
+    // for the contract.
+    bytes32[] private DEPRECATED_DO_NOT_USE;
 
-    // [user] => ([token=> collateraldata])
+    // We're only dealing with one token, but still using nested mapping to maintain backward-
+    // compatibility.
+    //
+    // [user] => ([collateralToken] => [CollateralData])
     mapping(address => mapping(bytes32 => CollateralData)) public userCollateralData;
 
-    // State variables added by upgrades
     IBuildBurnSystem public buildBurnSystem;
     address public liquidation;
 
+    uint8 private nonNativeCollateralDecimals;
+
+    bytes32 public constant NATIVE_CURRENCY = "ATH";
+    uint8 public constant NATIVE_CURRENCY_DECIMALS = 18;
     bytes32 public constant CONFIG_BUILD_RATIO = "BuildRatio";
 
     modifier onlyLiquidation() {
@@ -67,17 +99,18 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         _;
     }
 
-    /**
-     * @notice This function is deprecated as it doesn't do what its name suggests. Use
-     * `getFreeCollateralInUsd()` instead. This function is not removed since it's still
-     * used by `LnBuildBurnSystem`.
-     */
-    function MaxRedeemableInUsd(address _user) public view returns (uint256) {
-        return getFreeCollateralInUsd(_user);
+    // See notes on `nonNativeCollateralCurrency`.
+    function collateralCurrency() public view returns (bytes32) {
+        return uint256(nonNativeCollateralCurrency) == 0 ? NATIVE_CURRENCY : nonNativeCollateralCurrency;
     }
 
-    function getFreeCollateralInUsd(address user) public view returns (uint256) {
-        uint256 totalCollateralInUsd = GetUserTotalCollateralInUsd(user);
+    // See notes on `nonNativeCollateralDecimals`.
+    function collateralDecimals() public view returns (uint8) {
+        return uint256(nonNativeCollateralCurrency) == 0 ? NATIVE_CURRENCY_DECIMALS : nonNativeCollateralDecimals;
+    }
+
+    function getFreeCollateralInUsd(address user) external view returns (uint256) {
+        uint256 totalCollateralInUsd = _getUserTotalCollateralInUsd(user);
 
         (uint256 debtBalance,) = debtSystem.GetUserDebtBalanceInUsd(user);
         if (debtBalance == 0) {
@@ -93,25 +126,60 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         return totalCollateralInUsd.sub(minCollateral);
     }
 
-    function maxRedeemableLina(address user) public view returns (uint256) {
-        (uint256 debtBalance,) = debtSystem.GetUserDebtBalanceInUsd(user);
-        uint256 stakedLinaAmount = userCollateralData[user][Currency_LINA].collateral;
-
-        if (debtBalance == 0) {
-            // User doesn't have debt. All staked collateral is withdrawable
-            return stakedLinaAmount;
-        } else {
-            // User has debt. Must keep a certain amount
-            uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
-            uint256 minCollateralUsd = debtBalance.divideDecimal(buildRatio);
-            uint256 minCollateralLina = minCollateralUsd.divideDecimal(priceGetter.getPrice(Currency_LINA));
-            uint256 lockedLinaAmount = mRewardLocker.balanceOf(user);
-
-            return MathUpgradeable.min(stakedLinaAmount, stakedLinaAmount.add(lockedLinaAmount).sub(minCollateralLina));
-        }
+    // Despite the name, this function actually always returns the redeemable amount of the
+    // collateral managed by this contract instance, instead of the native currency.
+    function maxRedeemableLina(address user) external view returns (uint256) {
+        return _maxRedeemableLina(user);
     }
 
-    // -------------------------------------------------------
+    function GetSystemTotalCollateralInUsd() external view returns (uint256 rTotal) {
+        bytes32 _collateralCurrency = collateralCurrency();
+        uint256 collateralAmount = tokenInfos[_collateralCurrency].totalCollateral;
+        if (_collateralCurrency == NATIVE_CURRENCY) {
+            collateralAmount = collateralAmount.add(mRewardLocker.totalLockedAmount());
+        }
+
+        return collateralAmount.multiplyDecimalWith(priceGetter.getPrice(_collateralCurrency), collateralDecimals());
+    }
+
+    function GetUserTotalCollateralInUsd(address _user) external view returns (uint256 rTotal) {
+        return _getUserTotalCollateralInUsd(_user);
+    }
+
+    function GetUserCollateral(address _user, bytes32 _currency) external view returns (uint256) {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
+        // Staked balance
+        uint256 collateralAmount = userCollateralData[_user][_currency].collateral;
+
+        // Locked balance
+        if (_currency == NATIVE_CURRENCY) {
+            collateralAmount += mRewardLocker.balanceOf(_user);
+        }
+
+        return collateralAmount;
+    }
+
+    // Despite the name, this function actually always returns the breakdown of the collateral
+    // managed by this contract instance, instead of the native currency.
+    function getUserLinaCollateralBreakdown(address _user) external view returns (uint256 staked, uint256 locked) {
+        bytes32 _collateralCurrency = collateralCurrency();
+
+        uint256 stakedBalance = userCollateralData[_user][_collateralCurrency].collateral;
+
+        uint256 lockedBalance = 0;
+        if (_collateralCurrency == NATIVE_CURRENCY) {
+            lockedBalance = mRewardLocker.balanceOf(_user);
+        }
+
+        return (stakedBalance, lockedBalance);
+    }
+
+    function IsSatisfyTargetRatio(address _user) external view returns (bool) {
+        return isSatisfyTargetRatio(_user);
+    }
+
     function __CollateralSystem_init(
         IOracleRouter _priceGetter,
         IDebtSystem _debtSystem,
@@ -119,7 +187,7 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         IRewardLocker _mRewardLocker,
         IBuildBurnSystem _buildBurnSystem,
         address _liquidation
-    ) public initializer {
+    ) external initializer {
         __Ownable_init();
 
         require(address(_priceGetter) != address(0), "CollateralSystem: zero address");
@@ -138,12 +206,12 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
     }
 
     function setLiquidationAddress(address newAddress) external onlyOwner {
-        require(newAddress != address(0), "BuildBurnSystem: zero address");
+        require(newAddress != address(0), "CollateralSystem: zero address");
         liquidation = newAddress;
     }
 
     function setRewardLockerAddress(IRewardLocker newAddress) external onlyOwner {
-        require(address(newAddress) != address(0), "BuildBurnSystem: zero address");
+        require(address(newAddress) != address(0), "CollateralSystem: zero address");
         mRewardLocker = newAddress;
     }
 
@@ -155,126 +223,50 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         }
     }
 
-    function updateTokenInfo(bytes32 _currency, address _tokenAddr, uint256 _minCollateral, bool _close)
-        private
-        returns (bool)
-    {
-        require(_currency[0] != 0, "symbol cannot empty");
-        require(_currency != Currency_ETH, "ETH is used by system");
-        require(_tokenAddr != address(0), "token address cannot zero");
-        require(_tokenAddr.isContract(), "token address is not a contract");
-
-        if (tokenInfos[_currency].tokenAddr == address(0)) {
-            // new token
-            tokenSymbol.push(_currency);
-        }
-
-        uint256 totalCollateral = tokenInfos[_currency].totalCollateral;
-        tokenInfos[_currency] = TokenInfo({
-            tokenAddr: _tokenAddr,
-            minCollateral: _minCollateral,
-            totalCollateral: totalCollateral,
-            bClose: _close
-        });
-        emit UpdateTokenSetting(_currency, _tokenAddr, _minCollateral, _close);
-        return true;
-    }
-
-    // delete token info? need to handle it's staking data.
-
-    function UpdateTokenInfo(bytes32 _currency, address _tokenAddr, uint256 _minCollateral, bool _close)
+    // The original function allowed overwriting token info. We kept the interface in the rewrite
+    // but changed to only allow calling it once.
+    function updateTokenInfo(bytes32 _currency, address _tokenAddr, uint256 _minCollateral, bool _disabled)
         external
         onlyOwner
-        returns (bool)
     {
-        return updateTokenInfo(_currency, _tokenAddr, _minCollateral, _close);
-    }
+        require(uint256(_currency) != 0, "CollateralSystem: empty symbol");
+        require(_tokenAddr != address(0), "CollateralSystem: zero address");
 
-    function UpdateTokenInfos(
-        bytes32[] calldata _symbols,
-        address[] calldata _tokenAddrs,
-        uint256[] calldata _minCollateral,
-        bool[] calldata _closes
-    ) external onlyOwner returns (bool) {
-        require(_symbols.length == _tokenAddrs.length, "length of array not eq");
-        require(_symbols.length == _minCollateral.length, "length of array not eq");
-        require(_symbols.length == _closes.length, "length of array not eq");
+        require(uint256(nonNativeCollateralCurrency) == 0, "CollateralSystem: token info already set");
+        require(tokenInfos[_currency].tokenAddr == address(0), "CollateralSystem: token info already set");
 
-        for (uint256 i = 0; i < _symbols.length; i++) {
-            updateTokenInfo(_symbols[i], _tokenAddrs[i], _minCollateral[i], _closes[i]);
+        // Here we retain the same behavior in local environments as the previously deployed native
+        // collateral instance.
+        if (_currency != NATIVE_CURRENCY) {
+            nonNativeCollateralCurrency = _currency;
+            nonNativeCollateralDecimals = IERC20MetadataUpgradeable(_tokenAddr).decimals();
         }
 
+        tokenInfos[_currency] =
+            TokenInfo({tokenAddr: _tokenAddr, minCollateral: _minCollateral, totalCollateral: 0, disabled: _disabled});
+        emit UpdateTokenSetting(_currency, _tokenAddr, _minCollateral, _disabled);
+    }
+
+    function Collateral(bytes32 _currency, uint256 _amount) external whenNotPaused returns (bool) {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
+        return _collateral(msg.sender, _currency, _amount);
+    }
+
+    function Redeem(bytes32 _currency, uint256 _amount) external whenNotPaused returns (bool) {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
+        _redeem(msg.sender, _currency, _amount);
         return true;
     }
 
-    // ------------------------------------------------------------------------
-    function GetSystemTotalCollateralInUsd() public view returns (uint256 rTotal) {
-        for (uint256 i = 0; i < tokenSymbol.length; i++) {
-            bytes32 currency = tokenSymbol[i];
-            uint256 collateralAmount = tokenInfos[currency].totalCollateral;
-            if (Currency_LINA == currency) {
-                collateralAmount = collateralAmount.add(mRewardLocker.totalLockedAmount());
-            }
-            if (collateralAmount > 0) {
-                rTotal = rTotal.add(collateralAmount.multiplyDecimal(priceGetter.getPrice(currency)));
-            }
-        }
+    function RedeemMax(bytes32 _currency) external whenNotPaused {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
 
-        if (address(this).balance > 0) {
-            rTotal = rTotal.add(address(this).balance.multiplyDecimal(priceGetter.getPrice(Currency_ETH)));
-        }
-    }
-
-    function GetUserTotalCollateralInUsd(address _user) public view returns (uint256 rTotal) {
-        for (uint256 i = 0; i < tokenSymbol.length; i++) {
-            bytes32 currency = tokenSymbol[i];
-            uint256 collateralAmount = userCollateralData[_user][currency].collateral;
-            if (Currency_LINA == currency) {
-                collateralAmount = collateralAmount.add(mRewardLocker.balanceOf(_user));
-            }
-            if (collateralAmount > 0) {
-                rTotal = rTotal.add(collateralAmount.multiplyDecimal(priceGetter.getPrice(currency)));
-            }
-        }
-
-        if (userCollateralData[_user][Currency_ETH].collateral > 0) {
-            rTotal = rTotal.add(
-                userCollateralData[_user][Currency_ETH].collateral.multiplyDecimal(priceGetter.getPrice(Currency_ETH))
-            );
-        }
-    }
-
-    function GetUserCollateral(address _user, bytes32 _currency) external view returns (uint256) {
-        if (Currency_LINA != _currency) {
-            return userCollateralData[_user][_currency].collateral;
-        }
-        return mRewardLocker.balanceOf(_user).add(userCollateralData[_user][_currency].collateral);
-    }
-
-    function getUserLinaCollateralBreakdown(address _user) external view returns (uint256 staked, uint256 locked) {
-        return (userCollateralData[_user][Currency_LINA].collateral, mRewardLocker.balanceOf(_user));
-    }
-
-    // NOTE: LINA collateral not include reward in locker
-    function GetUserCollaterals(address _user) external view returns (bytes32[] memory, uint256[] memory) {
-        bytes32[] memory rCurrency = new bytes32[](tokenSymbol.length + 1);
-        uint256[] memory rAmount = new uint256[](tokenSymbol.length + 1);
-        uint256 retSize = 0;
-        for (uint256 i = 0; i < tokenSymbol.length; i++) {
-            bytes32 currency = tokenSymbol[i];
-            if (userCollateralData[_user][currency].collateral > 0) {
-                rCurrency[retSize] = currency;
-                rAmount[retSize] = userCollateralData[_user][currency].collateral;
-                retSize++;
-            }
-        }
-        if (userCollateralData[_user][Currency_ETH].collateral > 0) {
-            rCurrency[retSize] = Currency_ETH;
-            rAmount[retSize] = userCollateralData[_user][Currency_ETH].collateral;
-            retSize++;
-        }
-
-        return (rCurrency, rAmount);
+        _redeemMax(msg.sender, _currency);
     }
 
     /**
@@ -286,6 +278,9 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
      * @param buildAmount Amount of lUSD to build, can be zero
      */
     function stakeAndBuild(bytes32 stakeCurrency, uint256 stakeAmount, uint256 buildAmount) external whenNotPaused {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(stakeCurrency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
         require(stakeAmount > 0 || buildAmount > 0, "CollateralSystem: zero amount");
 
         if (stakeAmount > 0) {
@@ -304,6 +299,9 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
      * @param stakeAmount Amount of collateral currency to stake
      */
     function stakeAndBuildMax(bytes32 stakeCurrency, uint256 stakeAmount) external whenNotPaused {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(stakeCurrency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
         require(stakeAmount > 0, "CollateralSystem: zero amount");
 
         _collateral(msg.sender, stakeCurrency, stakeAmount);
@@ -322,6 +320,9 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         external
         whenNotPaused
     {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(unstakeCurrency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
         require(burnAmount > 0 || unstakeAmount > 0, "CollateralSystem: zero amount");
 
         if (burnAmount > 0) {
@@ -329,7 +330,7 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         }
 
         if (unstakeAmount > 0) {
-            _Redeem(msg.sender, unstakeCurrency, unstakeAmount);
+            _redeem(msg.sender, unstakeCurrency, unstakeAmount);
         }
     }
 
@@ -340,85 +341,13 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
      * @param unstakeCurrency ID of the collateral currency
      */
     function burnAndUnstakeMax(uint256 burnAmount, bytes32 unstakeCurrency) external whenNotPaused {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(unstakeCurrency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
         require(burnAmount > 0, "CollateralSystem: zero amount");
 
         buildBurnSystem.burnFromCollateralSys(msg.sender, burnAmount);
         _redeemMax(msg.sender, unstakeCurrency);
-    }
-
-    // need approve
-    function Collateral(bytes32 _currency, uint256 _amount) external whenNotPaused returns (bool) {
-        address user = msg.sender;
-        return _collateral(user, _currency, _amount);
-    }
-
-    function _collateral(address user, bytes32 _currency, uint256 _amount) private whenNotPaused returns (bool) {
-        require(tokenInfos[_currency].tokenAddr.isContract(), "Invalid token symbol");
-        TokenInfo storage tokeninfo = tokenInfos[_currency];
-        require(_amount > tokeninfo.minCollateral, "Collateral amount too small");
-        require(tokeninfo.bClose == false, "This token is closed");
-
-        IERC20Upgradeable erc20 = IERC20Upgradeable(tokenInfos[_currency].tokenAddr);
-        require(erc20.balanceOf(user) >= _amount, "insufficient balance");
-        require(erc20.allowance(user, address(this)) >= _amount, "insufficient allowance, need approve more amount");
-
-        erc20.transferFrom(user, address(this), _amount);
-
-        userCollateralData[user][_currency].collateral = userCollateralData[user][_currency].collateral.add(_amount);
-        tokeninfo.totalCollateral = tokeninfo.totalCollateral.add(_amount);
-
-        emit CollateralLog(user, _currency, _amount, userCollateralData[user][_currency].collateral);
-        return true;
-    }
-
-    function IsSatisfyTargetRatio(address _user) public view returns (bool) {
-        (uint256 debtBalance,) = debtSystem.GetUserDebtBalanceInUsd(_user);
-        if (debtBalance == 0) {
-            return true;
-        }
-
-        uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
-        uint256 totalCollateralInUsd = GetUserTotalCollateralInUsd(_user);
-        if (totalCollateralInUsd == 0) {
-            return false;
-        }
-        uint256 myratio = debtBalance.divideDecimal(totalCollateralInUsd);
-        return myratio <= buildRatio;
-    }
-
-    function RedeemMax(bytes32 _currency) external whenNotPaused {
-        _redeemMax(msg.sender, _currency);
-    }
-
-    function _redeemMax(address user, bytes32 _currency) private {
-        require(_currency == Currency_LINA, "CollateralSystem: only ATH is supported");
-        _Redeem(user, Currency_LINA, maxRedeemableLina(user));
-    }
-
-    function _Redeem(address user, bytes32 _currency, uint256 _amount) internal {
-        require(_currency == Currency_LINA, "CollateralSystem: only ATH is supported");
-        require(_amount > 0, "CollateralSystem: zero amount");
-
-        uint256 maxRedeemableLinaAmount = maxRedeemableLina(user);
-        require(_amount <= maxRedeemableLinaAmount, "CollateralSystem: insufficient collateral");
-
-        userCollateralData[user][Currency_LINA].collateral =
-            userCollateralData[user][Currency_LINA].collateral.sub(_amount);
-
-        TokenInfo storage tokeninfo = tokenInfos[Currency_LINA];
-        tokeninfo.totalCollateral = tokeninfo.totalCollateral.sub(_amount);
-
-        IERC20Upgradeable(tokeninfo.tokenAddr).transfer(user, _amount);
-
-        emit RedeemCollateral(user, Currency_LINA, _amount, userCollateralData[user][Currency_LINA].collateral);
-    }
-
-    // 1. After redeem, collateral ratio need bigger than target ratio.
-    // 2. Cannot redeem more than collateral.
-    function Redeem(bytes32 _currency, uint256 _amount) external whenNotPaused returns (bool) {
-        address user = msg.sender;
-        _Redeem(user, _currency, _amount);
-        return true;
     }
 
     function moveCollateral(address fromUser, address toUser, bytes32 currency, uint256 amount)
@@ -426,6 +355,9 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         whenNotPaused
         onlyLiquidation
     {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
         userCollateralData[fromUser][currency].collateral =
             userCollateralData[fromUser][currency].collateral.sub(amount);
         userCollateralData[toUser][currency].collateral = userCollateralData[toUser][currency].collateral.add(amount);
@@ -437,6 +369,9 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         whenNotPaused
         onlyRewardLocker
     {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
         require(user != address(0), "CollateralSystem: User address cannot be zero");
         require(amount > 0, "CollateralSystem: Collateral amount must be > 0");
 
@@ -451,9 +386,98 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
         emit CollateralUnlockReward(user, currency, amount, userCollateralData[user][currency].collateral);
     }
 
-    event UpdateTokenSetting(bytes32 symbol, address tokenAddr, uint256 minCollateral, bool close);
-    event CollateralLog(address user, bytes32 _currency, uint256 _amount, uint256 _userTotal);
-    event RedeemCollateral(address user, bytes32 _currency, uint256 _amount, uint256 _userTotal);
-    event CollateralMoved(address fromUser, address toUser, bytes32 currency, uint256 amount);
-    event CollateralUnlockReward(address user, bytes32 _currency, uint256 _amount, uint256 _userTotal);
+    function isSatisfyTargetRatio(address _user) private view returns (bool) {
+        (uint256 debtBalance,) = debtSystem.GetUserDebtBalanceInUsd(_user);
+        if (debtBalance == 0) {
+            return true;
+        }
+
+        uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
+        uint256 totalCollateralInUsd = _getUserTotalCollateralInUsd(_user);
+        if (totalCollateralInUsd == 0) {
+            return false;
+        }
+        uint256 myratio = debtBalance.divideDecimal(totalCollateralInUsd);
+        return myratio <= buildRatio;
+    }
+
+    function _getUserTotalCollateralInUsd(address _user) private view returns (uint256 rTotal) {
+        bytes32 _collateralCurrency = collateralCurrency();
+        uint256 collateralAmount = userCollateralData[_user][_collateralCurrency].collateral;
+        if (_collateralCurrency == NATIVE_CURRENCY) {
+            collateralAmount = collateralAmount.add(mRewardLocker.balanceOf(_user));
+        }
+
+        return collateralAmount.multiplyDecimalWith(priceGetter.getPrice(_collateralCurrency), collateralDecimals());
+    }
+
+    // Despite the name, this function actually always returns the redeemable amount of the
+    // collateral managed by this contract instance, instead of the native currency.
+    function _maxRedeemableLina(address user) private view returns (uint256) {
+        bytes32 _collateralCurrency = collateralCurrency();
+
+        (uint256 debtBalance,) = debtSystem.GetUserDebtBalanceInUsd(user);
+        uint256 stakedLinaAmount = userCollateralData[user][_collateralCurrency].collateral;
+
+        if (debtBalance == 0) {
+            // User doesn't have debt. All staked collateral is withdrawable
+            return stakedLinaAmount;
+        } else {
+            // User has debt. Must keep a certain amount
+            uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
+            uint256 minCollateralUsd = debtBalance.divideDecimal(buildRatio);
+            uint256 minCollateralLina =
+                minCollateralUsd.divideDecimalWith(priceGetter.getPrice(_collateralCurrency), collateralDecimals());
+
+            uint256 lockedLinaAmount = 0;
+            if (_collateralCurrency == NATIVE_CURRENCY) {
+                lockedLinaAmount = mRewardLocker.balanceOf(user);
+            }
+
+            return MathUpgradeable.min(stakedLinaAmount, stakedLinaAmount.add(lockedLinaAmount).sub(minCollateralLina));
+        }
+    }
+
+    function _collateral(address user, bytes32 _currency, uint256 _amount) private whenNotPaused returns (bool) {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
+        TokenInfo storage tokeninfo = tokenInfos[_currency];
+        require(_amount >= tokeninfo.minCollateral, "CollateralSystem: collateral amount too small");
+        require(!tokeninfo.disabled, "CollateralSystem: collateral disabled");
+
+        TransferHelper.safeTransferFrom(tokenInfos[_currency].tokenAddr, user, address(this), _amount);
+
+        userCollateralData[user][_currency].collateral = userCollateralData[user][_currency].collateral.add(_amount);
+        tokeninfo.totalCollateral = tokeninfo.totalCollateral.add(_amount);
+
+        emit CollateralLog(user, _currency, _amount, userCollateralData[user][_currency].collateral);
+        return true;
+    }
+
+    function _redeemMax(address user, bytes32 _currency) private {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
+        _redeem(user, _currency, _maxRedeemableLina(user));
+    }
+
+    function _redeem(address user, bytes32 _currency, uint256 _amount) private {
+        // We shouldn't even take this param. But still taking it for backward-compatibility.
+        require(_currency == collateralCurrency(), "CollateralSystem: currency symbol mismatch");
+
+        require(_amount > 0, "CollateralSystem: zero amount");
+
+        uint256 maxRedeemableLinaAmount = _maxRedeemableLina(user);
+        require(_amount <= maxRedeemableLinaAmount, "CollateralSystem: insufficient collateral");
+
+        userCollateralData[user][_currency].collateral = userCollateralData[user][_currency].collateral.sub(_amount);
+
+        TokenInfo storage tokeninfo = tokenInfos[_currency];
+        tokeninfo.totalCollateral = tokeninfo.totalCollateral.sub(_amount);
+
+        TransferHelper.safeTransfer(tokeninfo.tokenAddr, user, _amount);
+
+        emit RedeemCollateral(user, _currency, _amount, userCollateralData[user][_currency].collateral);
+    }
 }

--- a/src/CollateralSystem.sol
+++ b/src/CollateralSystem.sol
@@ -13,6 +13,7 @@ import "./interfaces/IDebtSystem.sol";
 import "./interfaces/IOracleRouter.sol";
 import "./interfaces/IRewardLocker.sol";
 import "./libraries/SafeDecimalMath.sol";
+import "./utilities/ConfigHelper.sol";
 import "./utilities/TransferHelper.sol";
 
 // Note to code reader by Tommy as of 2023-03-07:
@@ -87,7 +88,6 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
 
     bytes32 public constant NATIVE_CURRENCY = "ATH";
     uint8 public constant NATIVE_CURRENCY_DECIMALS = 18;
-    bytes32 public constant CONFIG_BUILD_RATIO = "BuildRatio";
 
     modifier onlyLiquidation() {
         require(msg.sender == liquidation, "CollateralSystem: not liquidation");
@@ -117,7 +117,7 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
             return totalCollateralInUsd;
         }
 
-        uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
+        uint256 buildRatio = mConfig.getUint(ConfigHelper.getBuildRatioKey(collateralCurrency()));
         uint256 minCollateral = debtBalance.divideDecimal(buildRatio);
         if (totalCollateralInUsd < minCollateral) {
             return 0;
@@ -392,7 +392,7 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
             return true;
         }
 
-        uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
+        uint256 buildRatio = mConfig.getUint(ConfigHelper.getBuildRatioKey(collateralCurrency()));
         uint256 totalCollateralInUsd = _getUserTotalCollateralInUsd(_user);
         if (totalCollateralInUsd == 0) {
             return false;
@@ -424,7 +424,7 @@ contract CollateralSystem is ICollateralSystem, PausableUpgradeable, OwnableUpgr
             return stakedLinaAmount;
         } else {
             // User has debt. Must keep a certain amount
-            uint256 buildRatio = mConfig.getUint(CONFIG_BUILD_RATIO);
+            uint256 buildRatio = mConfig.getUint(ConfigHelper.getBuildRatioKey(_collateralCurrency));
             uint256 minCollateralUsd = debtBalance.divideDecimal(buildRatio);
             uint256 minCollateralLina =
                 minCollateralUsd.divideDecimalWith(priceGetter.getPrice(_collateralCurrency), collateralDecimals());

--- a/src/DebtDistribution.sol
+++ b/src/DebtDistribution.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.15;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "./interfaces/IAssetRegistry.sol";
+import "./interfaces/IDebtDistribution.sol";
+import "./libraries/SafeDecimalMath.sol";
+
+/**
+ * @title DebtDistribution
+ *
+ * @dev This contract was added for the multi-collateral upgrade for distributing the aggregated
+ * debt amount proportionally to each collateral type. It works by requiring all `DebtSystem`
+ * instances to report to this contract whenever debt changes.
+ *
+ * This contract is invisible to consumers of `DebtSystem`, and is only used for coordination among
+ * `DebtSystem` instances.
+ *
+ * WARNING: this contract does not use SafeMath as it assumes a 0.8.0+ compiler. DO NOT use it on
+ *          older compiler versions without applying overflow protection.
+ */
+contract DebtDistribution is IDebtDistribution, OwnableUpgradeable {
+    using SafeDecimalMath for uint256;
+
+    event CollateralRegistered(address indexed debtSystemAddress, bytes32 indexed collteralSymbol);
+    event DebtUpdated(
+        address indexed debtSystemAddress,
+        bytes32 indexed collteralSymbol,
+        uint256 newCollateralProportion,
+        uint256 newGlobalDebtFactor
+    );
+
+    struct CollateralDebtData {
+        uint256 debtProportion;
+        uint256 debtFactor;
+    }
+
+    mapping(address => bytes32) public collateralSymbols;
+
+    // We use the exact same mechanism as in `DebtSystem` for tracking collateral debt proportions.
+    uint256 public globalDebtFactor;
+    mapping(address => CollateralDebtData) public collateralDebtData;
+
+    IAssetRegistry public assetRegistry;
+
+    modifier onlyRegisteredCollaterals() {
+        require(collateralSymbols[msg.sender] != bytes32(0), "DebtDistribution: permission denied");
+        _;
+    }
+
+    function getCollateralDebtBalanceByDebtSystemAddress(address _debtSystem) external view returns (uint256) {
+        (uint256 collateralDebtBalance,) = _getDebtBalances(_debtSystem);
+        return collateralDebtBalance;
+    }
+
+    function __DebtDistribution_init(IAssetRegistry _assetRegistry) external initializer {
+        __Ownable_init();
+
+        require(address(_assetRegistry) != address(0), "DebtDistribution: zero address");
+
+        assetRegistry = _assetRegistry;
+    }
+
+    function addCollateral(address _contractAddress, bytes32 _collateralSymbol) external onlyOwner {
+        collateralSymbols[_contractAddress] = _collateralSymbol;
+
+        emit CollateralRegistered(_contractAddress, _collateralSymbol);
+    }
+
+    function increaseDebt(uint256 _amount) external onlyRegisteredCollaterals {
+        _increaseDebt(msg.sender, _amount);
+    }
+
+    function decreaseDebt(uint256 _amount) external onlyRegisteredCollaterals {
+        _decreaseDebt(msg.sender, _amount);
+    }
+
+    function _getDebtBalances(address _debtSystem)
+        private
+        view
+        returns (uint256 collateralDebtBalance, uint256 systemDebtBalance)
+    {
+        systemDebtBalance = assetRegistry.totalAssetsInUsd();
+
+        uint256 debtProportion = collateralDebtData[_debtSystem].debtProportion;
+
+        if (debtProportion > 0) {
+            uint256 recordedDebtFactor = collateralDebtData[_debtSystem].debtFactor;
+            uint256 latestDebtProportion = (globalDebtFactor == 0 ? SafeDecimalMath.preciseUnit() : globalDebtFactor)
+                .divideDecimalRoundPrecise(recordedDebtFactor).multiplyDecimalRoundPrecise(debtProportion);
+
+            collateralDebtBalance = systemDebtBalance.decimalToPreciseDecimal().multiplyDecimalRoundPrecise(
+                latestDebtProportion
+            ).preciseDecimalToDecimal();
+        }
+    }
+
+    function _increaseDebt(address _debtSystemAddress, uint256 _amount) private {
+        (uint256 oldCollateralDebtBalance, uint256 oldSystemDebtBalance) = _getDebtBalances(_debtSystemAddress);
+
+        uint256 newCollateralDebtBalance = oldCollateralDebtBalance + _amount;
+        uint256 newSystemDebtBalance = oldSystemDebtBalance + _amount;
+        uint256 amountProportion = _amount.divideDecimalRoundPrecise(newSystemDebtBalance);
+
+        uint256 newCollateralDebtProportion = newCollateralDebtBalance.divideDecimalRoundPrecise(newSystemDebtBalance);
+        uint256 oldDebtProportion = SafeDecimalMath.preciseUnit() - amountProportion;
+
+        _updateDebt(_debtSystemAddress, newCollateralDebtProportion, oldDebtProportion);
+    }
+
+    function _decreaseDebt(address _debtSystemAddress, uint256 _amount) private {
+        (uint256 oldCollateralDebtBalance, uint256 oldSystemDebtBalance) = _getDebtBalances(_debtSystemAddress);
+
+        uint256 newCollateralDebtBalance = oldCollateralDebtBalance - _amount;
+        uint256 newSystemDebtBalance = oldSystemDebtBalance - _amount;
+
+        uint256 newCollateralDebtProportion = newCollateralDebtBalance.divideDecimalRoundPrecise(newSystemDebtBalance);
+
+        uint256 oldDebtProportion;
+        if (newSystemDebtBalance > 0) {
+            uint256 amountProportion = _amount.divideDecimalRoundPrecise(newSystemDebtBalance);
+            oldDebtProportion = SafeDecimalMath.preciseUnit() + amountProportion;
+        } else {
+            oldDebtProportion = 0;
+        }
+
+        _updateDebt(_debtSystemAddress, newCollateralDebtProportion, oldDebtProportion);
+    }
+
+    function _updateDebt(address _debtSystemAddress, uint256 _debtProportion, uint256 _factor) private {
+        uint256 newGlobalDebtFactor = globalDebtFactor == 0
+            ? SafeDecimalMath.preciseUnit()
+            : globalDebtFactor.multiplyDecimalRoundPrecise(_factor);
+        globalDebtFactor = newGlobalDebtFactor;
+
+        collateralDebtData[_debtSystemAddress] =
+            CollateralDebtData({debtProportion: _debtProportion, debtFactor: newGlobalDebtFactor});
+
+        emit DebtUpdated(
+            _debtSystemAddress, collateralSymbols[_debtSystemAddress], _debtProportion, newGlobalDebtFactor
+        );
+    }
+}

--- a/src/DebtSystem.sol
+++ b/src/DebtSystem.sol
@@ -8,30 +8,67 @@ import "./interfaces/IAssetRegistry.sol";
 import "./interfaces/IDebtSystem.sol";
 import "./libraries/SafeDecimalMath.sol";
 
+// Note to code reader by Tommy as of 2023-03-07:
+//
+// This contract has been mostly rewritten after it's been deployed in production to properly
+// support multi-collateral, with backward compatibility as a hard requirement.
+//
+// The original codebase has a questionable design of storing the latest "debt factor" values in an
+// array whereas the only thing that's actually needed would be the latest value. It's meant to
+// have a mechanism for deleting old values but it never actually kicks in as the trigger condition
+// is never satisfied. This has caused a significant waste of gas for end users.
+//
+// To eventually move away from the questionable design, the multi-collateral upgrade changes to
+// _also_ persist the latest value to a single slot, but never to actually use it. Once we make
+// sure the on-chain value of this new slot syncs with the array value, we can make another upgrade
+// to stop writing to the array for good.
+//
+// As such, the will be seemingly weird implementations across the contract that might make you
+// wonder why it's even coded that way. Most likely it's for backward compatibility with the
+// previous implementation. For more details check Git history.
 contract DebtSystem is IDebtSystem, OwnableUpgradeable {
     using SafeDecimalMath for uint256;
     using SafeMathUpgradeable for uint256;
 
-    // -------------------------------------------------------
-    // need set before system running value.
+    event UpdateUserDebtLog(address addr, uint256 debtProportion, uint256 debtFactor, uint256 timestamp);
+    event PushDebtLog(uint256 index, uint256 newFactor, uint256 timestamp);
+
+    struct UserDebtData {
+        uint256 debtProportion;
+        uint256 debtFactor;
+    }
+
     IAccessControlUpgradeable public accessCtrl;
     IAssetRegistry public assetSys;
 
-    // -------------------------------------------------------
-    struct DebtData {
-        uint256 debtProportion;
-        uint256 debtFactor; // PRECISE_UNIT
-    }
+    mapping(address => UserDebtData) public userDebtState;
 
-    mapping(address => DebtData) public userDebtState;
+    // These two fields are the result of the original questionable design. See the rewrite note at
+    // the top for more details.
+    mapping(uint256 => uint256) public lastDebtFactors;
+    uint256 public debtCurrentIndex;
 
-    //use mapping to store array data
-    mapping(uint256 => uint256) public lastDebtFactors; // PRECISE_UNIT Note: 能直接记 factor 的记 factor, 不能记的就用index查
-    uint256 public debtCurrentIndex; // length of array. this index of array no value
-    // follow var use to manage array size.
-    uint256 public lastCloseAt; // close at array index
-    uint256 public lastDeletTo; // delete to array index, lastDeletTo < lastCloseAt
-    uint256 public constant MAX_DEL_PER_TIME = 50;
+    // There were originally two storage vars here: `lastCloseAt` and `lastDeletTo`, which were
+    // supposed to power the old storage data pruning mechanism. However, it turned out to be
+    // unused. We can safely remove them and repurpose the slots as they are and will stay zero.
+
+    // The global debt factor for this collateral managed by this contract instance.
+    //
+    // To understand this field, imagine the owner of the first ever debt entry under this
+    // collateral to have never performed any action after the initial mint.
+    //
+    // With this setup, this number represents the proportion of the that first ever debt with
+    // regard to the current debt pool. Natually, this number shrinks over time as other users
+    // would build up debt as well.
+    //
+    // Why is this useful? Well, at any point in time, when any user makes any changes to his/her
+    // debt, the current "global debt factor" can be recorded. At a later time, we can compare this
+    // previously marked down value with the actual lastest value to figure out how much the debt
+    // proportion of this specific user have changed. We can then derive the latest proportion of
+    // the user's debt with regard to the entire debt pool.
+    //
+    // This mechanism enables efficient tracking of everyone's debt in O(1).
+    uint256 public collateralDebtFactor;
 
     bytes32 private constant ROLE_UPDATE_DEBT = "UPDATE_DEBT";
 
@@ -40,89 +77,11 @@ contract DebtSystem is IDebtSystem, OwnableUpgradeable {
         _;
     }
 
-    function __DebtSystem_init(IAccessControlUpgradeable _accessCtrl, IAssetRegistry _assetSys) public initializer {
-        __Ownable_init();
-
-        require(address(_accessCtrl) != address(0), "DebtSystem: zero address");
-        require(address(_assetSys) != address(0), "DebtSystem: zero address");
-
-        accessCtrl = _accessCtrl;
-        assetSys = _assetSys;
-    }
-
-    event UpdateAddressStorage(address oldAddr, address newAddr);
-    event UpdateUserDebtLog(address addr, uint256 debtProportion, uint256 debtFactor, uint256 timestamp);
-    event PushDebtLog(uint256 index, uint256 newFactor, uint256 timestamp);
-
-    function _pushDebtFactor(uint256 _factor) private {
-        if (debtCurrentIndex == 0 || lastDebtFactors[debtCurrentIndex - 1] == 0) {
-            // init or all debt has be cleared, new set value will be one unit
-            lastDebtFactors[debtCurrentIndex] = SafeDecimalMath.preciseUnit();
-        } else {
-            lastDebtFactors[debtCurrentIndex] =
-                lastDebtFactors[debtCurrentIndex - 1].multiplyDecimalRoundPrecise(_factor);
-        }
-        emit PushDebtLog(debtCurrentIndex, lastDebtFactors[debtCurrentIndex], block.timestamp);
-
-        debtCurrentIndex = debtCurrentIndex.add(1);
-
-        // delete out of date data
-        if (lastDeletTo < lastCloseAt) {
-            // safe check
-            uint256 delNum = lastCloseAt - lastDeletTo;
-            delNum = delNum > MAX_DEL_PER_TIME ? MAX_DEL_PER_TIME : delNum; // not delete all in one call, for saving someone fee.
-            for (uint256 i = lastDeletTo; i < delNum; i++) {
-                delete lastDebtFactors[i];
-            }
-            lastDeletTo = lastDeletTo.add(delNum);
-        }
-    }
-
-    function _updateUserDebt(address _user, uint256 _debtProportion) private {
-        userDebtState[_user].debtProportion = _debtProportion;
-        userDebtState[_user].debtFactor = _lastSystemDebtFactor();
-        emit UpdateUserDebtLog(_user, _debtProportion, userDebtState[_user].debtFactor, block.timestamp);
-    }
-
-    function UpdateDebt(address _user, uint256 _debtProportion, uint256 _factor) external onlyUpdateDebtRole {
-        _pushDebtFactor(_factor);
-        _updateUserDebt(_user, _debtProportion);
-    }
-
-    function GetUserDebtData(address _user) external view returns (uint256 debtProportion, uint256 debtFactor) {
-        debtProportion = userDebtState[_user].debtProportion;
-        debtFactor = userDebtState[_user].debtFactor;
-    }
-
-    function _lastSystemDebtFactor() private view returns (uint256) {
-        if (debtCurrentIndex == 0) {
-            return SafeDecimalMath.preciseUnit();
-        }
-        return lastDebtFactors[debtCurrentIndex - 1];
-    }
-
-    function LastSystemDebtFactor() external view returns (uint256) {
-        return _lastSystemDebtFactor();
-    }
-
-    function GetUserCurrentDebtProportion(address _user) public view returns (uint256) {
-        uint256 debtProportion = userDebtState[_user].debtProportion;
-        uint256 debtFactor = userDebtState[_user].debtFactor;
-
-        if (debtProportion == 0) {
-            return 0;
-        }
-
-        uint256 currentUserDebtProportion =
-            _lastSystemDebtFactor().divideDecimalRoundPrecise(debtFactor).multiplyDecimalRoundPrecise(debtProportion);
-        return currentUserDebtProportion;
-    }
-
     /**
-     *
      * @return [0] the debt balance of user. [1] system total asset in usd.
      */
     function GetUserDebtBalanceInUsd(address _user) external view returns (uint256, uint256) {
+        // TODO: adjust this value for this collateral
         uint256 totalAssetSupplyInUsd = assetSys.totalAssetsInUsd();
 
         uint256 debtProportion = userDebtState[_user].debtProportion;
@@ -139,5 +98,53 @@ contract DebtSystem is IDebtSystem, OwnableUpgradeable {
         ).preciseDecimalToDecimal();
 
         return (userDebtBalance, totalAssetSupplyInUsd);
+    }
+
+    function __DebtSystem_init(IAccessControlUpgradeable _accessCtrl, IAssetRegistry _assetSys) external initializer {
+        __Ownable_init();
+
+        require(address(_accessCtrl) != address(0), "DebtSystem: zero address");
+        require(address(_assetSys) != address(0), "DebtSystem: zero address");
+
+        accessCtrl = _accessCtrl;
+        assetSys = _assetSys;
+    }
+
+    function UpdateDebt(address _user, uint256 _debtProportion, uint256 _factor) external onlyUpdateDebtRole {
+        _pushDebtFactor(_factor);
+        _updateUserDebt(_user, _debtProportion);
+    }
+
+    function _lastSystemDebtFactor() private view returns (uint256) {
+        if (debtCurrentIndex == 0) {
+            return SafeDecimalMath.preciseUnit();
+        }
+        return lastDebtFactors[debtCurrentIndex - 1];
+    }
+
+    function _pushDebtFactor(uint256 _factor) private {
+        // This is the old questionable logic. We're keeping it here until the next upgrade
+        {
+            if (debtCurrentIndex == 0 || lastDebtFactors[debtCurrentIndex - 1] == 0) {
+                // init or all debt has be cleared, new set value will be one unit
+                lastDebtFactors[debtCurrentIndex] = SafeDecimalMath.preciseUnit();
+            } else {
+                lastDebtFactors[debtCurrentIndex] =
+                    lastDebtFactors[debtCurrentIndex - 1].multiplyDecimalRoundPrecise(_factor);
+            }
+            emit PushDebtLog(debtCurrentIndex, lastDebtFactors[debtCurrentIndex], block.timestamp);
+
+            debtCurrentIndex = debtCurrentIndex.add(1);
+        }
+
+        // This new storage slot is what enables use to get rid of the legacy logic above in the
+        // next upgrade.
+        collateralDebtFactor = lastDebtFactors[debtCurrentIndex - 1];
+    }
+
+    function _updateUserDebt(address _user, uint256 _debtProportion) private {
+        userDebtState[_user].debtProportion = _debtProportion;
+        userDebtState[_user].debtFactor = _lastSystemDebtFactor();
+        emit UpdateUserDebtLog(_user, _debtProportion, userDebtState[_user].debtFactor, block.timestamp);
     }
 }

--- a/src/Liquidation.sol
+++ b/src/Liquidation.sol
@@ -41,6 +41,7 @@ contract Liquidation is OwnableUpgradeable {
         uint256 stakedCollateral;
         uint256 lockedCollateral;
         uint256 collateralPrice;
+        uint8 collateralDecimals;
         uint256 collateralValue;
         uint256 collateralizationRatio;
     }
@@ -208,7 +209,11 @@ contract Liquidation is OwnableUpgradeable {
         buildBurnSystem.burnForLiquidation(params.user, params.liquidator, params.lusdToBurn);
 
         LiquidationRewardCalculationResult memory rewards = calculateRewards(
-            params.lusdToBurn, evalResult.collateralPrice, ratios.markerRewardRatio, ratios.liquidatorRewardRatio
+            params.lusdToBurn,
+            evalResult.collateralPrice,
+            evalResult.collateralDecimals,
+            ratios.markerRewardRatio,
+            ratios.liquidatorRewardRatio
         );
 
         {
@@ -263,7 +268,7 @@ contract Liquidation is OwnableUpgradeable {
             mark.marker,
             params.liquidator,
             params.lusdToBurn,
-            "ATH",
+            collateralSystem.collateralCurrency(),
             totalFromStaked,
             totalFromLocked,
             rewards.markerReward,
@@ -281,8 +286,11 @@ contract Liquidation is OwnableUpgradeable {
         (uint256 debtBalance,) = debtSystem.GetUserDebtBalanceInUsd(user);
         (uint256 stakedCollateral, uint256 lockedCollateral) = collateralSystem.getUserLinaCollateralBreakdown(user);
 
-        uint256 collateralPrice = oracleRouter.getPrice("ATH");
-        uint256 collateralValue = stakedCollateral.add(lockedCollateral).multiplyDecimal(collateralPrice);
+        uint8 collateralDecimals = collateralSystem.collateralDecimals();
+
+        uint256 collateralPrice = oracleRouter.getPrice(collateralSystem.collateralCurrency());
+        uint256 collateralValue =
+            stakedCollateral.add(lockedCollateral).multiplyDecimalWith(collateralPrice, collateralDecimals);
 
         uint256 collateralizationRatio = collateralValue == 0 ? 0 : debtBalance.divideDecimal(collateralValue);
         return EvalUserPositionResult({
@@ -290,6 +298,7 @@ contract Liquidation is OwnableUpgradeable {
             stakedCollateral: stakedCollateral,
             lockedCollateral: lockedCollateral,
             collateralPrice: collateralPrice,
+            collateralDecimals: collateralDecimals,
             collateralValue: collateralValue,
             collateralizationRatio: collateralizationRatio
         });
@@ -313,11 +322,12 @@ contract Liquidation is OwnableUpgradeable {
     function calculateRewards(
         uint256 lusdToBurn,
         uint256 collateralPrice,
+        uint8 collateralDecimals,
         uint256 markerRewardRatio,
         uint256 liquidatorRewardRatio
     ) private pure returns (LiquidationRewardCalculationResult memory) {
         // Amount of collateral with the same value as the debt burnt (without taking into account rewards)
-        uint256 collateralWithdrawalAmount = lusdToBurn.divideDecimal(collateralPrice);
+        uint256 collateralWithdrawalAmount = lusdToBurn.divideDecimalWith(collateralPrice, collateralDecimals);
 
         // Reward amounts
         uint256 markerReward = collateralWithdrawalAmount.multiplyDecimal(markerRewardRatio);
@@ -342,7 +352,9 @@ contract Liquidation is OwnableUpgradeable {
         require(amountFromLocked <= params.lockedCollateral, "Liquidation: insufficient locked collateral");
 
         if (amountFromStaked > 0) {
-            collateralSystem.moveCollateral(params.user, params.liquidator, "ATH", amountFromStaked);
+            collateralSystem.moveCollateral(
+                params.user, params.liquidator, collateralSystem.collateralCurrency(), amountFromStaked
+            );
         }
 
         if (amountFromLocked > 0) {
@@ -371,8 +383,12 @@ contract Liquidation is OwnableUpgradeable {
             markerRewardFromLocked = markerRewardFromLocked.sub(markerRewardFromStaked);
             liquidatorRewardFromLocked = liquidatorRewardFromLocked.sub(liquidatorRewardFromStaked);
 
-            collateralSystem.moveCollateral(params.user, params.marker, "ATH", markerRewardFromStaked);
-            collateralSystem.moveCollateral(params.user, params.liquidator, "ATH", liquidatorRewardFromStaked);
+            collateralSystem.moveCollateral(
+                params.user, params.marker, collateralSystem.collateralCurrency(), markerRewardFromStaked
+            );
+            collateralSystem.moveCollateral(
+                params.user, params.liquidator, collateralSystem.collateralCurrency(), liquidatorRewardFromStaked
+            );
         }
 
         if (amountFromLocked > 0) {

--- a/src/interfaces/ICollateralSystem.sol
+++ b/src/interfaces/ICollateralSystem.sol
@@ -8,8 +8,6 @@ interface ICollateralSystem {
 
     function GetUserTotalCollateralInUsd(address _user) external view returns (uint256 rTotal);
 
-    function MaxRedeemableInUsd(address _user) external view returns (uint256);
-
     function getFreeCollateralInUsd(address user) external view returns (uint256);
 
     function moveCollateral(address fromUser, address toUser, bytes32 currency, uint256 amount) external;

--- a/src/interfaces/ICollateralSystem.sol
+++ b/src/interfaces/ICollateralSystem.sol
@@ -4,6 +4,8 @@ pragma solidity >=0.6.12 <0.9.0;
 interface ICollateralSystem {
     function collateralCurrency() external view returns (bytes32);
 
+    function collateralDecimals() external view returns (uint8);
+
     function getUserLinaCollateralBreakdown(address _user) external view returns (uint256 staked, uint256 locked);
 
     function IsSatisfyTargetRatio(address _user) external view returns (bool);

--- a/src/interfaces/ICollateralSystem.sol
+++ b/src/interfaces/ICollateralSystem.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.6.12 <0.9.0;
 
 interface ICollateralSystem {
+    function collateralCurrency() external view returns (bytes32);
+
     function getUserLinaCollateralBreakdown(address _user) external view returns (uint256 staked, uint256 locked);
 
     function IsSatisfyTargetRatio(address _user) external view returns (bool);

--- a/src/interfaces/IDebtDistribution.sol
+++ b/src/interfaces/IDebtDistribution.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.12 <0.9.0;
+
+interface IDebtDistribution {
+    function getCollateralDebtBalanceByDebtSystemAddress(address _debtSystem) external view returns (uint256);
+
+    function increaseDebt(uint256 _amount) external;
+
+    function decreaseDebt(uint256 _amount) external;
+}

--- a/src/interfaces/IDebtSystem.sol
+++ b/src/interfaces/IDebtSystem.sol
@@ -4,5 +4,7 @@ pragma solidity >=0.6.12 <0.9.0;
 interface IDebtSystem {
     function GetUserDebtBalanceInUsd(address _user) external view returns (uint256, uint256);
 
-    function UpdateDebt(address _user, uint256 _debtProportion, uint256 _factor) external;
+    function increaseDebt(address _user, uint256 _amount) external;
+
+    function decreaseDebt(address _user, uint256 _amount) external;
 }

--- a/src/libraries/SafeDecimalMath.sol
+++ b/src/libraries/SafeDecimalMath.sol
@@ -22,6 +22,10 @@ library SafeDecimalMath {
         return x * y / UNIT;
     }
 
+    function multiplyDecimalWith(uint256 x, uint256 y, uint8 _decimals) internal pure returns (uint256) {
+        return x * y / (10 ** _decimals);
+    }
+
     function _multiplyDecimalRound(uint256 x, uint256 y, uint256 precisionUnit) private pure returns (uint256) {
         uint256 quotientTimesTen = x * y / (precisionUnit / 10);
 
@@ -42,6 +46,10 @@ library SafeDecimalMath {
 
     function divideDecimal(uint256 x, uint256 y) internal pure returns (uint256) {
         return x * UNIT / y;
+    }
+
+    function divideDecimalWith(uint256 x, uint256 y, uint8 _decimals) internal pure returns (uint256) {
+        return x * (10 ** _decimals) / y;
     }
 
     function _divideDecimalRound(uint256 x, uint256 y, uint256 precisionUnit) private pure returns (uint256) {

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -10,7 +10,15 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
  * use it for production.
  */
 contract MockERC20 is ERC20 {
-    constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) {}
+    uint8 private __decimals;
+
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) ERC20(_name, _symbol) {
+        __decimals = _decimals;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return __decimals;
+    }
 
     function mint(address account, uint256 amount) external {
         _mint(account, amount);

--- a/src/utilities/ConfigHelper.sol
+++ b/src/utilities/ConfigHelper.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.9.0;
+
+/**
+ * @title ConfigHelper
+ *
+ * @dev A helper library for calculating collateral-specific config keys.
+ */
+library ConfigHelper {
+    bytes32 private constant NATIVE_CURRENCY = "ATH";
+
+    function getBuildRatioKey(bytes32 currency) internal pure returns (bytes32) {
+        return handleKey(bytes32("BuildRatio"), bytes32("BuildRatio"), currency);
+    }
+
+    function getLiquidationRatioKey(bytes32 currency) internal pure returns (bytes32) {
+        return handleKey(bytes32("LiquidationRatio"), bytes32("LiqRatio"), currency);
+    }
+
+    function getLiquidationDelayKey(bytes32 currency) internal pure returns (bytes32) {
+        return handleKey(bytes32("LiquidationDelay"), bytes32("LiqDelay"), currency);
+    }
+
+    function getLiquidationMarkerRewardKey(bytes32 currency) internal pure returns (bytes32) {
+        return handleKey(bytes32("LiquidationMarkerReward"), bytes32("LiqMarkerReward"), currency);
+    }
+
+    function getLiquidationLiquidatorRewardKey(bytes32 currency) internal pure returns (bytes32) {
+        return handleKey(bytes32("LiquidationLiquidatorReward"), bytes32("LiqLiquidatorReward"), currency);
+    }
+
+    function handleKey(bytes32 fallbackKey, bytes32 offsetKey, bytes32 currency) internal pure returns (bytes32) {
+        // Backward compatibility
+        if (currency == NATIVE_CURRENCY) {
+            return fallbackKey;
+        }
+
+        return prefixWithCurrency(offsetKey, currency);
+    }
+
+    function prefixWithCurrency(bytes32 rawKey, bytes32 currency) private pure returns (bytes32) {
+        uint8 currencyLength = contentLength(currency);
+        bytes32 mixedKey = currency | (rawKey >> ((currencyLength + 1) * 8) | (bytes32("_") >> (currencyLength * 8)));
+
+        return (mixedKey);
+    }
+
+    function contentLength(bytes32 value) private pure returns (uint8) {
+        for (uint8 ind = 0; ind <= 31; ind++) {
+            if (value[ind] == 0) {
+                return ind;
+            }
+        }
+        return 32;
+    }
+}


### PR DESCRIPTION
This PR adds the multi-collateral functionality.

Currently only the native token `ATH` can be used for building `athUSD`, which limits `athUSD` liquidity. With multi-collateral enabled, users can build `athUSD` from other designated collateral tokens as well.

Each collateral can have different parameters in terms of `athUSD` minting and liquidation. Debts from different collateral tokens under the same user are also completely separated. For example, an unhealthy `ATH` debt position will not result in a healthy `WBTC` position being liquidated, even if they're under the same user.