### PR TITLE
fix: incorrect oracle decimal scaling

### DIFF
--- a/src/UniswapTwapOracle.sol
+++ b/src/UniswapTwapOracle.sol
@@ -130,7 +130,7 @@ contract UniswapTwapOracle is IUniswapTwapOracle, AccessControlUpgradeable {
         } else if (baseDecimal < PRICE_DECIMALS) {
             price = rawUniswapPriceMantissa * 10 ** (PRICE_DECIMALS - baseDecimal);
         } else {
-            price = rawUniswapPriceMantissa * 10 ** (baseDecimal - PRICE_DECIMALS);
+            price = rawUniswapPriceMantissa / 10 ** (baseDecimal - PRICE_DECIMALS);
         }
     }
 }


### PR DESCRIPTION
This PR fixes an incorrect handling of decimals in `UniswapTwapOracle`. We haven't encountered any issue so far in production as this branch was never executed.